### PR TITLE
Reverse blue and red channels in color image

### DIFF
--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -119,7 +119,8 @@ void compressImage(const cv::Mat& image, const char* compressing_format,
                        int compressing_quality,
                        sensor_msgs::CompressedImage* compressed_image) {
   cv::Mat image_good_endcoding = cv::Mat();
-  cv::cvtColor(image, image_good_endcoding, cv::COLOR_YUV420sp2RGBA);
+  // OpenCV expects an image with channels in BGR order for compressing.
+  cv::cvtColor(image, image_good_endcoding, cv::COLOR_YUV420sp2BGRA);
   std::vector<int> params {CV_IMWRITE_JPEG_QUALITY, compressing_quality};
   cv::imencode(compressing_format, image_good_endcoding, compressed_image->data, params);
 }


### PR DESCRIPTION
This PR fixes the channel order of the camera color image. The Red and Blue channels were inverted.