### PR TITLE
Fix copying generated dynamic_reconfigure headers from devel to src s…

### DIFF
--- a/tango_ros_common/tango_ros_native/CMakeLists.txt
+++ b/tango_ros_common/tango_ros_native/CMakeLists.txt
@@ -55,11 +55,12 @@ install(TARGETS tango_ros_native
 # Copy generated header files by dynamic reconfigure into local include folder.
 # Otherwise these header files can not be found when building for Android.
 set(dynamic_reconfigure_header_LOCATION ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/PublisherConfig.h)
-set(dynamic_reconfigure_header_DESTINATION ${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/)
-file(COPY ${dynamic_reconfigure_header_LOCATION}
-  DESTINATION ${dynamic_reconfigure_header_DESTINATION}
+set(dynamic_reconfigure_header_DESTINATION ${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/PublisherConfig.h)
+add_custom_command(
+  OUTPUT ${dynamic_reconfigure_header_DESTINATION}
+  DEPENDS ${dynamic_reconfigure_header_LOCATION}
+  COMMAND cmake -E copy ${dynamic_reconfigure_header_LOCATION} ${dynamic_reconfigure_header_DESTINATION}
 )
-
 
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(${PROJECT_NAME}_test_tango_ros test/test_tango_ros_msg.cpp)


### PR DESCRIPTION
…pace

Fixes #84. As it is not possible to declare a cmake dependency for a file(COPY)
command, replacing it by a custom command is the recommended way of doing this.

@PerrineAguiar Maybe we should in a follow-up PR look into how we can avoid this source space pollution and just have the project point to the right place in the devel space?

PTAL