### PR TITLE
Add custom target to force copying the dyn_reconf header

### DIFF
--- a/tango_ros_common/tango_ros_native/CMakeLists.txt
+++ b/tango_ros_common/tango_ros_native/CMakeLists.txt
@@ -61,6 +61,7 @@ add_custom_command(
   DEPENDS ${dynamic_reconfigure_header_LOCATION}
   COMMAND cmake -E copy ${dynamic_reconfigure_header_LOCATION} ${dynamic_reconfigure_header_DESTINATION}
 )
+add_custom_target(copy ALL DEPENDS ${dynamic_reconfigure_header_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(${PROJECT_NAME}_test_tango_ros test/test_tango_ros_msg.cpp)


### PR DESCRIPTION
As there was no target depending on the output of the custom command the
file did not get copied, adding a custom cmake target that's added to the
all target this will always happen.

This was surfaced by trying to build the android app. I verified it solves the issue.