### PR TITLE
Fix linking error for tango_ros_native.

### DIFF
--- a/tango_ros_common/tango_ros_native/Android.mk
+++ b/tango_ros_common/tango_ros_native/Android.mk
@@ -16,6 +16,7 @@ LOCAL_LDLIBS += -landroid -lm -llog
 LOCAL_STATIC_LIBRARIES += roscpp_android_ndk miniglog
 LOCAL_SHARED_LIBRARIES := tango_client_api tango_support_api
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/include
+LOCAL_DISABLE_FATAL_LINKER_WARNINGS=true
 include $(BUILD_SHARED_LIBRARY)
 
 include $(PROJECT_ROOT)/../third_party/miniglog/Android.mk


### PR DESCRIPTION
Fixes #89
There are some linking warnings about boost in ros libraries, as there is no
way to fix those easily atm, not escallating those warnings to errors seems
the best approach for now.