### PR TITLE
Feature/point cloud as laser scan

### DIFF
--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/RunningActivity.java
@@ -318,6 +318,7 @@ public class RunningActivity extends AppCompatRosActivity implements TangoRosNod
         String[] dynamicParams = {
                 getString(R.string.publish_device_pose_key),
                 getString(R.string.publish_point_cloud_key),
+                getString(R.string.publish_laser_scan_key),
                 getString(R.string.publish_color_camera_key),
                 getString(R.string.publish_fisheye_camera_key)};
         // Tango configuration parameters are non-runtime settings for now.

--- a/TangoRosStreamer/app/src/main/res/values/strings.xml
+++ b/TangoRosStreamer/app/src/main/res/values/strings.xml
@@ -38,6 +38,9 @@
     <string name="publish_point_cloud">Point cloud</string>
     <string name="publish_point_cloud_key">publish_point_cloud</string>
 
+    <string name="publish_laser_scan">Laser scan</string>
+    <string name="publish_laser_scan_key">publish_laser_scan</string>
+
     <string name="publish_fisheye_camera">Fisheye image</string>
     <string name="publish_fisheye_camera_key">publish_fisheye_camera</string>
 

--- a/TangoRosStreamer/app/src/main/res/xml/pref_running.xml
+++ b/TangoRosStreamer/app/src/main/res/xml/pref_running.xml
@@ -13,6 +13,10 @@
             android:title="@string/publish_point_cloud" />
 
         <SwitchPreference
+            android:key="@string/publish_laser_scan_key"
+            android:title="@string/publish_laser_scan" />
+
+        <SwitchPreference
             android:key="@string/publish_fisheye_camera_key"
             android:title="@string/publish_fisheye_camera" />
 

--- a/tango_ros_common/tango_ros_native/cfg/Publisher.cfg
+++ b/tango_ros_common/tango_ros_native/cfg/Publisher.cfg
@@ -7,6 +7,7 @@ gen = ParameterGenerator()
 
 gen.add("publish_device_pose",    bool_t ,    0, "boolean publish_device_pose",    False)
 gen.add("publish_point_cloud",    bool_t ,    0, "boolean publish_point_cloud",    False)
+gen.add("publish_laser_scan",     bool_t ,    0, "boolean publish_laser_scan",     False)
 gen.add("publish_fisheye_camera", bool_t ,    0, "boolean publish_fisheye_camera", False)
 gen.add("publish_color_camera",   bool_t ,    0, "boolean publish_color_camera",   False)
 

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
@@ -39,6 +39,13 @@
 namespace tango_ros_native {
 const std::string NODE_NAME = "tango";
 const int NUMBER_OF_FIELDS_IN_POINT_CLOUD = 4;
+const float LASER_SCAN_ANGLE_MIN = 0.;
+const float LASER_SCAN_ANGLE_MAX = 3.1415;
+const float LASER_SCAN_ANGLE_INCREMENT = 3.1415 / 360;
+const float LASER_SCAN_TIME_INCREMENT = 0.0;
+const float LASER_SCAN_SCAN_TIME= 0.3333;
+const float LASER_SCAN_RANGE_MIN = 0.45;
+const float LASER_SCAN_RANGE_MAX = 6.0;
 const std::string LASER_SCAN_FRAME_ID = "laser";
 constexpr char CV_IMAGE_COMPRESSING_FORMAT[] = ".jpg";
 constexpr char ROS_IMAGE_COMPRESSING_FORMAT[] = "jpeg";
@@ -159,8 +166,8 @@ class TangoRosNode {
   ros::Publisher laser_scan_publisher_;
   sensor_msgs::LaserScan laser_scan_;
   // TODO: make these ros params.
-  double min_height_ = 0;
-  double max_height_ = 2.0;
+  double laser_scan_min_height_ = 0;
+  double laser_scan_max_height_ = 2.0;
 
   ros::Publisher fisheye_image_publisher_;
   sensor_msgs::CompressedImage fisheye_compressed_image_;

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
@@ -59,6 +59,8 @@ struct PublisherConfiguration {
 
   // Topic name for the point cloud publisher.
   std::string point_cloud_topic = "tango/point_cloud";
+  // Topic name for the point cloud publisher.
+  std::string laser_scan_topic = "tango/laser_scan";
   // Topic name for the fisheye image publisher.
   std::string fisheye_camera_topic = "tango/camera/fisheye_1/image_raw/compressed";
   // Topic name for the color image publisher.
@@ -139,11 +141,13 @@ class TangoRosNode {
   geometry_msgs::TransformStamped start_of_service_T_device_;
   tf2_ros::StaticTransformBroadcaster tf_static_broadcaster_;
   geometry_msgs::TransformStamped device_T_camera_depth_;
+  geometry_msgs::TransformStamped camera_depth_T_laser_;
   geometry_msgs::TransformStamped device_T_camera_fisheye_;
   geometry_msgs::TransformStamped device_T_camera_color_;
 
   ros::Publisher point_cloud_publisher_;
   sensor_msgs::PointCloud2 point_cloud_;
+  ros::Publisher laser_scan_publisher_;
 
   ros::Publisher fisheye_image_publisher_;
   sensor_msgs::CompressedImage fisheye_compressed_image_;

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
@@ -29,6 +29,7 @@
 #include <ros/ros.h>
 #include <ros/node_handle.h>
 #include <sensor_msgs/CompressedImage.h>
+#include <sensor_msgs/LaserScan.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <tf/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
@@ -38,6 +39,7 @@
 namespace tango_ros_native {
 const std::string NODE_NAME = "tango";
 const int NUMBER_OF_FIELDS_IN_POINT_CLOUD = 4;
+const std::string LASER_SCAN_FRAME_ID = "laser";
 constexpr char CV_IMAGE_COMPRESSING_FORMAT[] = ".jpg";
 constexpr char ROS_IMAGE_COMPRESSING_FORMAT[] = "jpeg";
 // Compressing quality for OpenCV to compress an image to JPEG format,
@@ -54,12 +56,14 @@ struct PublisherConfiguration {
   std::atomic_bool publish_device_pose{false};
   // True if point cloud needs to be published.
   std::atomic_bool publish_point_cloud{false};
+  // True if laser scan needs to be published.
+  std::atomic_bool publish_laser_scan{false};
   // Flag corresponding to which cameras need to be published.
   std::atomic<uint32_t> publish_camera{CAMERA_NONE};
 
   // Topic name for the point cloud publisher.
   std::string point_cloud_topic = "tango/point_cloud";
-  // Topic name for the point cloud publisher.
+  // Topic name for the laser scan publisher.
   std::string laser_scan_topic = "tango/laser_scan";
   // Topic name for the fisheye image publisher.
   std::string fisheye_camera_topic = "tango/camera/fisheye_1/image_raw/compressed";
@@ -103,9 +107,10 @@ class TangoRosNode {
   TangoErrorType TangoConnect();
   // Publishes the necessary static transforms (device_T_camera_*).
   void PublishStaticTransforms();
-  // Publishes the available data (device pose, point cloud, images).
+  // Publishes the available data (device pose, point cloud, laser scan, images).
   void PublishDevicePose();
   void PublishPointCloud();
+  void PublishLaserScan();
   void PublishFisheyeImage();
   void PublishColorImage();
   // Runs ros::spinOnce() in a loop to trigger subscribers callbacks (e.g. dynamic reconfigure).
@@ -121,6 +126,7 @@ class TangoRosNode {
   PublisherConfiguration publisher_config_;
   std::thread publish_device_pose_thread_;
   std::thread publish_pointcloud_thread_;
+  std::thread publish_laserscan_thread_;
   std::thread publish_fisheye_image_thread_;
   std::thread publish_color_image_thread_;
   std::thread ros_spin_thread_;
@@ -130,6 +136,8 @@ class TangoRosNode {
   std::condition_variable pose_available_;
   std::mutex point_cloud_available_mutex_;
   std::condition_variable point_cloud_available_;
+  std::mutex laser_scan_available_mutex_;
+  std::condition_variable laser_scan_available_;
   std::mutex fisheye_image_available_mutex_;
   std::condition_variable fisheye_image_available_;
   std::mutex color_image_available_mutex_;
@@ -147,7 +155,12 @@ class TangoRosNode {
 
   ros::Publisher point_cloud_publisher_;
   sensor_msgs::PointCloud2 point_cloud_;
+
   ros::Publisher laser_scan_publisher_;
+  sensor_msgs::LaserScan laser_scan_;
+  // TODO: make these ros params.
+  double min_height_ = 0;
+  double max_height_ = 2.0;
 
   ros::Publisher fisheye_image_publisher_;
   sensor_msgs::CompressedImage fisheye_compressed_image_;

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -176,59 +176,6 @@ void toLaserScan(const TangoPointCloud& tango_point_cloud,
   }
   laser_scan->header.stamp.fromSec((tango_point_cloud.timestamp + time_offset) / 1e3);
 }
-// Converts a TangoPointCloud to a sensor_msgs::PointCloud2 and a
-// sensor_msgs::LaserScan.
-// @param tango_point_cloud, TangoPointCloud to convert.
-// @param time_offset, offset in ms between tango_point_cloud (tango time) and
-//        point_cloud/laser_scan (ros time).
-// @param min_height minimum height for a point of the point cloud to be
-// included in laser scan.
-// @param max_height maximum height for a point of the point cloud to be
-// included in laser scan.
-// @param point_cloud, the output PointCloud2.
-// @param laser_scan, the output LaserScan.
-void toPointCloud2AndLaserScan(const TangoPointCloud& tango_point_cloud,
-                   double time_offset,
-                   double min_height,
-                   double max_height,
-                   sensor_msgs::PointCloud2* point_cloud,
-                   sensor_msgs::LaserScan* laser_scan) {
-  point_cloud->width = tango_point_cloud.num_points;
-  point_cloud->height = 1;
-  point_cloud->point_step = (sizeof(float) * tango_ros_native::NUMBER_OF_FIELDS_IN_POINT_CLOUD);
-  point_cloud->is_dense = true;
-  point_cloud->row_step = point_cloud->width;
-  point_cloud->is_bigendian = false;
-  point_cloud->data.resize(tango_point_cloud.num_points);
-  sensor_msgs::PointCloud2Modifier modifier(*point_cloud);
-  modifier.setPointCloud2Fields(tango_ros_native::NUMBER_OF_FIELDS_IN_POINT_CLOUD,
-                                "x", 1, sensor_msgs::PointField::FLOAT32,
-                                "y", 1, sensor_msgs::PointField::FLOAT32,
-                                "z", 1, sensor_msgs::PointField::FLOAT32,
-                                "c", 1, sensor_msgs::PointField::FLOAT32);
-  modifier.resize(tango_point_cloud.num_points);
-  sensor_msgs::PointCloud2Iterator<float> iter_x(*point_cloud, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(*point_cloud, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(*point_cloud, "z");
-  sensor_msgs::PointCloud2Iterator<float> iter_c(*point_cloud, "c");
-  for (size_t i = 0; i < tango_point_cloud.num_points;
-      ++i, ++iter_x, ++iter_y, ++iter_z, ++iter_c) {
-    // Fill in point cloud message.
-    *iter_x = tango_point_cloud.points[i][0];
-    *iter_y = tango_point_cloud.points[i][1];
-    *iter_z = tango_point_cloud.points[i][2];
-    *iter_c = tango_point_cloud.points[i][3];
-
-    // Laser scan frame is rotated of 90 degrees around x axis with respect to
-    // point cloud frame.
-    double x = tango_point_cloud.points[i][0];
-    double y = tango_point_cloud.points[i][2];
-    double z = -tango_point_cloud.points[i][1];
-    toLaserScanRange(x, y, z, min_height, max_height, laser_scan);
-  }
-  point_cloud->header.stamp.fromSec((tango_point_cloud.timestamp + time_offset) / 1e3);
-  laser_scan->header = point_cloud->header;
-}
 // Compresses a cv::Mat image to a sensor_msgs::CompressedImage in JPEG format.
 // @param image, cv::Mat to compress, in YUV420sp format.
 // @param compressing_quality, value from 0 to 100 (the higher is the better).
@@ -542,38 +489,31 @@ void TangoRosNode::OnPoseAvailable(const TangoPoseData* pose) {
 }
 
 void TangoRosNode::OnPointCloudAvailable(const TangoPointCloud* point_cloud) {
-  if (publisher_config_.publish_laser_scan && point_cloud->num_points > 0
-      && laser_scan_available_mutex_.try_lock()) {
-    laser_scan_.angle_min = LASER_SCAN_ANGLE_MIN;
-    laser_scan_.angle_max = LASER_SCAN_ANGLE_MAX;
-    laser_scan_.angle_increment = LASER_SCAN_ANGLE_INCREMENT;
-    laser_scan_.time_increment = LASER_SCAN_TIME_INCREMENT;
-    laser_scan_.scan_time = LASER_SCAN_SCAN_TIME;
-    laser_scan_.range_min = LASER_SCAN_RANGE_MIN;
-    laser_scan_.range_max = LASER_SCAN_RANGE_MAX;
-    // Determine amount of rays to create.
-    uint32_t ranges_size = std::ceil((laser_scan_.angle_max - laser_scan_.angle_min)
-                                     / laser_scan_.angle_increment);
-    // Laser scan rays with no obstacle data will evaluate to infinity.
-    laser_scan_.ranges.assign(ranges_size, std::numeric_limits<double>::infinity());
+  if (point_cloud->num_points > 0) {
     if (publisher_config_.publish_point_cloud && point_cloud_available_mutex_.try_lock()) {
-      toPointCloud2AndLaserScan(*point_cloud, time_offset_, laser_scan_min_height_,
-                               laser_scan_max_height_, &point_cloud_, &laser_scan_);
+      toPointCloud2(*point_cloud, time_offset_, &point_cloud_);
       point_cloud_.header.frame_id = toFrameId(TANGO_COORDINATE_FRAME_CAMERA_DEPTH);
       point_cloud_available_.notify_all();
       point_cloud_available_mutex_.unlock();
-    } else {
-      toLaserScan(*point_cloud, time_offset_, laser_scan_min_height_, laser_scan_max_height_, &laser_scan_);
     }
-    laser_scan_.header.frame_id = LASER_SCAN_FRAME_ID;
-    laser_scan_available_.notify_all();
-    laser_scan_available_mutex_.unlock();
-  } else if (publisher_config_.publish_point_cloud && point_cloud->num_points > 0
-      && point_cloud_available_mutex_.try_lock()) {
-    toPointCloud2(*point_cloud, time_offset_, &point_cloud_);
-    point_cloud_.header.frame_id = toFrameId(TANGO_COORDINATE_FRAME_CAMERA_DEPTH);
-    point_cloud_available_.notify_all();
-    point_cloud_available_mutex_.unlock();
+    if (publisher_config_.publish_laser_scan && laser_scan_available_mutex_.try_lock()) {
+      laser_scan_.angle_min = LASER_SCAN_ANGLE_MIN;
+      laser_scan_.angle_max = LASER_SCAN_ANGLE_MAX;
+      laser_scan_.angle_increment = LASER_SCAN_ANGLE_INCREMENT;
+      laser_scan_.time_increment = LASER_SCAN_TIME_INCREMENT;
+      laser_scan_.scan_time = LASER_SCAN_SCAN_TIME;
+      laser_scan_.range_min = LASER_SCAN_RANGE_MIN;
+      laser_scan_.range_max = LASER_SCAN_RANGE_MAX;
+      // Determine amount of rays to create.
+      uint32_t ranges_size = std::ceil((laser_scan_.angle_max - laser_scan_.angle_min)
+                                       / laser_scan_.angle_increment);
+      // Laser scan rays with no obstacle data will evaluate to infinity.
+      laser_scan_.ranges.assign(ranges_size, std::numeric_limits<double>::infinity());
+      toLaserScan(*point_cloud, time_offset_, laser_scan_min_height_, laser_scan_max_height_, &laser_scan_);
+      laser_scan_.header.frame_id = LASER_SCAN_FRAME_ID;
+      laser_scan_available_.notify_all();
+      laser_scan_available_mutex_.unlock();
+    }
   }
 }
 

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -77,7 +77,6 @@ void toTransformStamped(const TangoPoseData& pose,
   transform->transform.rotation.w = pose.orientation[3];
   transform->header.stamp.fromSec((pose.timestamp + time_offset) / 1e3);
 }
-
 // Converts a TangoPointCloud to a sensor_msgs::PointCloud2.
 // @param tango_point_cloud, TangoPointCloud to convert.
 // @param time_offset, offset in ms between tango_point_cloud (tango time) and
@@ -114,7 +113,6 @@ void toPointCloud2(const TangoPointCloud& tango_point_cloud,
   }
   point_cloud->header.stamp.fromSec((tango_point_cloud.timestamp + time_offset) / 1e3);
 }
-
 // Convert a point to a laser scan range.
 // Method taken from the ros package 'pointcloud_to_laserscan':
 // http://wiki.ros.org/pointcloud_to_laserscan
@@ -153,7 +151,6 @@ void toLaserScanRange(double x, double y, double z, double min_height,
     laser_scan->ranges[index] = range;
   }
 }
-
 // Converts a TangoPointCloud to a sensor_msgs::LaserScan.
 // @param tango_point_cloud, TangoPointCloud to convert.
 // @param time_offset, offset in ms between tango_point_cloud (tango time) and
@@ -179,8 +176,6 @@ void toLaserScan(const TangoPointCloud& tango_point_cloud,
   }
   laser_scan->header.stamp.fromSec((tango_point_cloud.timestamp + time_offset) / 1e3);
 }
-
-
 // Converts a TangoPointCloud to a sensor_msgs::PointCloud2 and a
 // sensor_msgs::LaserScan.
 // @param tango_point_cloud, TangoPointCloud to convert.
@@ -234,8 +229,6 @@ void toPointCloud2AndLaserScan(const TangoPointCloud& tango_point_cloud,
   point_cloud->header.stamp.fromSec((tango_point_cloud.timestamp + time_offset) / 1e3);
   laser_scan->header = point_cloud->header;
 }
-
-
 // Compresses a cv::Mat image to a sensor_msgs::CompressedImage in JPEG format.
 // @param image, cv::Mat to compress, in YUV420sp format.
 // @param compressing_quality, value from 0 to 100 (the higher is the better).

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -105,7 +105,6 @@ void toPointCloud2(const TangoPointCloud& tango_point_cloud,
   sensor_msgs::PointCloud2Iterator<float> iter_c(*point_cloud, "c");
   for (size_t i = 0; i < tango_point_cloud.num_points;
       ++i, ++iter_x, ++iter_y, ++iter_z, ++iter_c) {
-    // Fill in point cloud message.
     *iter_x = tango_point_cloud.points[i][0];
     *iter_y = tango_point_cloud.points[i][1];
     *iter_z = tango_point_cloud.points[i][2];
@@ -166,7 +165,6 @@ void toLaserScan(const TangoPointCloud& tango_point_cloud,
                    double max_height,
                    sensor_msgs::LaserScan* laser_scan) {
   for (size_t i = 0; i < tango_point_cloud.num_points; ++i) {
-    // Fill in laser scan message.
     // Laser scan frame is rotated of 90 degrees around x axis with respect to
     // point cloud frame.
     double x = tango_point_cloud.points[i][0];


### PR DESCRIPTION
This PR allows publishing a laser scan message computed from the tango point cloud.
The method to convert the point cloud to a laser scan is taken from the ros package [point_cloud_to_laser_scan](http://wiki.ros.org/pointcloud_to_laserscan). 

Fixes #126.