### PR TITLE
Fix: Timestamps in seconds

### DIFF
--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
@@ -150,7 +150,7 @@ class TangoRosNode {
   std::mutex color_image_available_mutex_;
   std::condition_variable color_image_available_;
 
-  double time_offset_ = 0.; // Offset between tango time and ros time in ms.
+  double time_offset_ = 0.; // Offset between tango time and ros time in s.
 
   tf::TransformBroadcaster tf_broadcaster_;
   geometry_msgs::TransformStamped start_of_service_T_device_;


### PR DESCRIPTION
I realized that the timestamp of the messages being published (for example, device's pose) wasn't changing over time correctly. In fact, the third most significant digit in the "nanoseconds" part of the stamp goes up each time a second passes.

The Tango documentation isn't extremely clear about it, but I believe the API returns the timestamp in seconds.
For example, when describing [pose interface](https://developers.google.com/tango/apis/c/reference/group/pose#tangoservice_connectonposeavailable) or the [point cloud structure](https://developers.google.com/tango/apis/c/reference/struct/tango-point-cloud), it explicitly says that the unit of measure is seconds.
That's not the case for [tango pose data](https://developers.google.com/tango/apis/c/reference/struct/tango-pose-data.html#struct_tango_pose_data) - it's not specified. And I believe there is a mistake in [this example](https://developers.google.com/tango/overview/poses).

With this change, the timestamp of the pose changes as it should. I changed all the other timestamps too to be consistent.