### PR TITLE
Feature: wrap application as a Catkin package

### DIFF
--- a/TangoRosStreamer/CMakeLists.txt
+++ b/TangoRosStreamer/CMakeLists.txt
@@ -1,0 +1,25 @@
+##############################################################################
+# CMake
+##############################################################################
+
+cmake_minimum_required(VERSION 2.8.3)
+project(tango_ros_streamer)
+
+##############################################################################
+# Catkin
+##############################################################################
+
+find_package(catkin REQUIRED rosjava_build_tools)
+# Set the gradle targets you want catkin's make to run by default
+# e.g. usually catkin_android_setup(assembleRelease uploadArchives)
+catkin_android_setup(assembleRelease assembleDebug uploadArchives)
+catkin_package()
+
+
+##############################################################################
+# Installation
+##############################################################################
+
+# Deploy android libraries (.aar's) and applications (.apk's)
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_MAVEN_DESTINATION}/com/github/rosjava/${PROJECT_NAME}/ 
+       DESTINATION ${CATKIN_GLOBAL_MAVEN_DESTINATION}/com/github/rosjava/${PROJECT_NAME}/)

--- a/TangoRosStreamer/build.gradle
+++ b/TangoRosStreamer/build.gradle
@@ -22,6 +22,14 @@ buildscript {
     apply from: "https://github.com/rosjava/android_core/raw/kinetic/buildscript.gradle"
 }
 
+apply plugin: 'catkin'
+
+allprojects {
+    /* A github url provides a good standard unique name for your project */
+    group 'eu.intermodalics'
+    version = project.catkin.pkg.version
+}
+
 subprojects {
     apply plugin: 'ros-android'
 

--- a/TangoRosStreamer/package.xml
+++ b/TangoRosStreamer/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>tango_ros_streamer</name>
-  <version>0.1.0</version>
+  <version>1.0.13</version>
   <description>This package wraps Tango Ros Streamer application</description>
 
   <maintainer email="ruben@intermodalics.eu">Ruben Smits</maintainer>

--- a/TangoRosStreamer/package.xml
+++ b/TangoRosStreamer/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package>
+  <name>tango_ros_streamer</name>
+  <version>0.1.0</version>
+  <description>This package wraps Tango Ros Streamer application</description>
+
+  <maintainer email="ruben@intermodalics.eu">Ruben Smits</maintainer>
+  <maintainer email="perrine@intermodalics.eu">Perrine Aguiar</maintainer>
+  <license>Apache</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>tango_ros_native</build_depend>
+  <build_depend>rosjava_build_tools</build_depend>
+
+</package>

--- a/TangoRosStreamer/tango_ros_node/build.gradle
+++ b/TangoRosStreamer/tango_ros_node/build.gradle
@@ -59,7 +59,7 @@ task ndkBuild(type: Exec) {
 
 dependencies {
     // e.g. official msgs
-    compile('org.ros.rosjava_core:rosjava:[0.3.0]') {
+    compile('org.ros.rosjava_core:rosjava:[0.3, 0.4)') {
         exclude group: 'junit'
         exclude group: 'xml-apis'
     }

--- a/tango_ros_common/tango_ros_native/CMakeLists.txt
+++ b/tango_ros_common/tango_ros_native/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
    )
 
 find_package(cmake_modules REQUIRED)
-find_package(OpenCV 2 REQUIRED)
+find_package(OpenCV 3 REQUIRED)
 
 generate_dynamic_reconfigure_options(
   cfg/Publisher.cfg


### PR DESCRIPTION
This PR wraps the application inside a Catkin package.
Why is this useful/ important?
-The app can now be built running `catkin_make` from the root workspace folder after sourcing ROS kinetic environment. This command will create the apk file too.
-Using catkin_make, the app and the node's artifacts are uploaded to the local workspace Maven repository (tango_ros_ws/devel/share/maven). This allows using the code for the `TangoRosNode` by sourcing the app's workspace after running catkin_make (`source tango_ros_ws/devel/setup.bash`).

Note 1: OpenCV version was changed to 3 in `tango_ros_native` CMakelists'. OpenCV 3 is the [default for ROS kinetic](http://wiki.ros.org/opencv3). This doesn't seem to cause problems. See #102 .
Note 2: When running catkin_make the first time, glog (third party dependency) downloads some code required to build. Apparently there is a race condition and catkin keeps on building the application before the download is finished, so the first time it fails. It doesn't happen running `catkin_make -j1`.
Note 3: even though `catkin_make` and `catkin_make_isolated` work, I get an error with `catkin build` when the android NDK tries to build the miniglog. I couldn't figure out what is happening here; @PerrineAguiar would you please take a look?
