### PR TITLE
Fix imu timestamp

### DIFF
--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/ImuNode.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/ImuNode.java
@@ -43,7 +43,6 @@ public class ImuNode extends AbstractNodeMain implements NodeMain, SensorEventLi
     private Imu mImuMessage;
     private Log mLog;
 
-
     private SensorManager mSensorManager;
     private Sensor mRotationSensor;
     private Sensor mGyroscopeSensor;
@@ -107,7 +106,6 @@ public class ImuNode extends AbstractNodeMain implements NodeMain, SensorEventLi
             default:
                 break;
         }
-
         if (mNewRotationData && mNewGyroscopeData && mNewAccelerometerData) {
             mImuMessage.getHeader().setStamp(mConnectedNode.getCurrentTime());
             mImuMessage.getHeader().setFrameId("imu");

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -388,6 +388,7 @@ TangoErrorType TangoRosNode::OnTangoServiceConnected() {
     LOG(ERROR) << "Error, could not get a first valid pose.";
     return TANGO_INVALID;
   }
+  time_offset_ =  ros::Time::now().toSec() - pose.timestamp;
 
   TangoCameraIntrinsics tango_camera_intrinsics;
   TangoService_getCameraIntrinsics(TANGO_CAMERA_FISHEYE, &tango_camera_intrinsics);
@@ -407,7 +408,6 @@ TangoErrorType TangoRosNode::OnTangoServiceConnected() {
   // Cache camera model for more efficiency.
   color_camera_model_.fromCameraInfo(color_camera_info_);
 
-  time_offset_ =  ros::Time::now().toSec() - pose.timestamp;
   return TANGO_SUCCESS;
 }
 


### PR DESCRIPTION
This PR fixes the timestamp value of the IMU message.

The error seen in rviz was: 
TF error: [Lookup would require extrapolation into the future. Requested time 1487337410.255000000 but the latest data is at time 1487240508.901808739, when looking up transform from frame [imu] to frame [start_of_service]]