### PR TITLE
Do not publish if transform is empty

### DIFF
--- a/TangoRosStreamer/app/src/main/AndroidManifest.xml
+++ b/TangoRosStreamer/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="eu.intermodalics.tango_ros_streamer"
-    android:versionCode="11"
+    android:versionCode="13"
     android:versionName="1.0">
 
     <uses-permission android:name="android.permission.CAMERA" />

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -704,7 +704,10 @@ void TangoRosNode::PublishDevicePose() {
       pose_available_.wait(lock);
       if (publisher_config_.publish_device_pose) {
         tf_broadcaster_.sendTransform(start_of_service_T_device_);
-        tf_broadcaster_.sendTransform(area_description_T_start_of_service_);
+        if (area_description_T_start_of_service_.child_frame_id != "") {
+          // This transform can be empty. Don't publish it in this case.
+          tf_broadcaster_.sendTransform(area_description_T_start_of_service_);
+        }
       }
     }
   }


### PR DESCRIPTION
An empty transform is published when drift correction is not enable.
This PR fixes this bug.