### PR TITLE
Fix: Upgraded compile SDK version to 25

### DIFF
--- a/TangoRosStreamer/app/build.gradle
+++ b/TangoRosStreamer/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "eu.intermodalics.tango_ros_streamer"
@@ -27,7 +27,7 @@ dependencies {
     compile 'org.ros.rosjava_messages:sensor_msgs:[0.3,)'
     compile 'org.ros.rosjava_messages:geometry_msgs:[0.3,)'
     compile 'org.ros.rosjava_messages:dynamic_reconfigure:[0.3,)'
-    compile 'com.android.support:support-v4:22.2.1'
-    compile 'com.android.support:design:22.2.1'
+    compile 'com.android.support:support-v4:25.2.0'
+    compile 'com.android.support:design:25.2.0'
     compile project(':tango_ros_node')
 }


### PR DESCRIPTION
The error reported by @juergensturm in #162 shows up because of the new version of Android_10 in [rosjava_mvn_repo](https://github.com/rosjava/rosjava_mvn_repo/pull/26), which corresponds to [this PR](https://github.com/rosjava/android_core/pull/253). 

Compile SDK version was set to 22 when App Compat was contributed to [Android Core](https://github.com/rosjava/android_core) because version 25 had some problems (see discussion [here](https://github.com/rosjava/android_core/pull/249)). The thing is that using version 22 broke some apps in [Android extras](https://github.com/rosjava/android_extras) repository, and the original problem caused by using SDK 25 in Android Core was fixed, so the version was finally reverted to 25.

This PR updates the SDK version to for the application, allowing to build it using the upgraded dependencies. This should get rid of the error in #162 .
