### PR TITLE
Fix: Using OpenCV 2 OR 3

### DIFF
--- a/tango_ros_common/tango_ros_native/CMakeLists.txt
+++ b/tango_ros_common/tango_ros_native/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
    tf2_ros
    )
 
+# Use OpenCV3 if we are using ROS Kinetic (which is the default for that distro)
 if( $ENV{ROS_DISTRO} STRLESS "kinetic")
   find_package(OpenCV 2 REQUIRED)
 else()

--- a/tango_ros_common/tango_ros_native/CMakeLists.txt
+++ b/tango_ros_common/tango_ros_native/CMakeLists.txt
@@ -14,8 +14,11 @@ find_package(catkin REQUIRED COMPONENTS
    tf2_ros
    )
 
-find_package(cmake_modules REQUIRED)
-find_package(OpenCV 3 REQUIRED)
+if( $ENV{ROS_DISTRO} STRLESS "kinetic")
+  find_package(OpenCV 2 REQUIRED)
+else()
+  find_package(OpenCV 3 REQUIRED)
+endif()
 
 generate_dynamic_reconfigure_options(
   cfg/Publisher.cfg

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -431,7 +431,7 @@ TangoErrorType TangoRosNode::TangoSetupConfig() {
 
   bool enable_drift_correction = false;
   int localization_mode;
-  node_handle_.param(publisher_config_.localization_mode_param, localization_mode, LocalizationMode::ODOMETRY);
+  node_handle_.param(publisher_config_.localization_mode_param, localization_mode, (int) LocalizationMode::ODOMETRY);
   if (localization_mode == LocalizationMode::ONLINE_SLAM) {
     enable_drift_correction = true;
   }


### PR DESCRIPTION
Now that #152 is merged, the OpenCV version was changed to 3. This may cause problems when building the app with Indigo, as the default version is 2 in that distro.
This PR allows to use version 2 or 3, so that the project can be built using Indigo and Kinetic.

This solves #102 .