### PR TITLE
Feature/load dataset

### DIFF
--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/RunningActivity.java
@@ -57,6 +57,10 @@ public class RunningActivity extends AppCompatRosActivity implements TangoRosNod
     private static final String TAGS_TO_LOG = TAG + ", " + "tango_client_api, " + "Registrar, "
             + "DefaultPublisher, " + "native, " + "DefaultPublisher" ;
     private static final int LOG_TEXT_MAX_LENGTH = 5000;
+    private static final String EXTRA_KEY_PERMISSIONTYPE = "PERMISSIONTYPE";
+    private static final String EXTRA_VALUE_DATASET = "DATASET_PERMISSION";
+    private static final String REQUEST_PERMISSION_ACTION = "android.intent.action.REQUEST_TANGO_PERMISSION";
+    private static final int REQUEST_CODE_TANGO_PERMISSION = 111;
 
     public static class startSettingsActivityRequest {
         public static final int FIRST_RUN = 1;
@@ -225,6 +229,15 @@ public class RunningActivity extends AppCompatRosActivity implements TangoRosNod
                 getString(R.string.pref_log_file_default));
         setupUI();
         mLogger = new Logger(this, mLogTextView, TAGS_TO_LOG, logFileName, LOG_TEXT_MAX_LENGTH);
+
+        getPermission(EXTRA_VALUE_DATASET);
+    }
+
+    private void getPermission(String permissionType) {
+        Intent intent = new Intent();
+        intent.setAction(REQUEST_PERMISSION_ACTION);
+        intent.putExtra(EXTRA_KEY_PERMISSIONTYPE, permissionType);
+        startActivityForResult(intent, REQUEST_CODE_TANGO_PERMISSION);
     }
 
     @Override
@@ -300,6 +313,13 @@ public class RunningActivity extends AppCompatRosActivity implements TangoRosNod
                 String logFileName = mSharedPref.getString(getString(R.string.pref_log_file_key),
                         getString(R.string.pref_log_file_default));
                 mLogger.setLogFileName(logFileName);
+            }
+        }
+
+        if (requestCode == REQUEST_CODE_TANGO_PERMISSION) {
+            if (resultCode == RESULT_CANCELED) {
+                // No Tango permissions granted by the user.
+                finish();
             }
         }
     }

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
@@ -53,6 +53,7 @@ const float LASER_SCAN_SCAN_TIME= 0.3333;
 const float LASER_SCAN_RANGE_MIN = 0.15;
 const float LASER_SCAN_RANGE_MAX = 4.0;
 const std::string LASER_SCAN_FRAME_ID = "laser";
+const std::string DATASETS_PATH = "/sdcard/tango_ros_streamer/datasets/";
 
 // Camera bitfield values.
 const uint32_t CAMERA_NONE = 0;

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
@@ -96,6 +96,10 @@ struct PublisherConfiguration {
   std::string color_rectified_image_topic = "tango/camera/color_1/image_rect";
   // Param name for the drift correction parameter.
   std::string localization_mode_param = "tango/localization_mode";
+  // Param name for the dataset base folder.
+  std::string datasets_path = "tango/dataset_datasets_path";
+  // Param name for the dataset UUID.
+  std::string dataset_uuid = "tango/dataset_uuid";
 };
 
 // Node collecting tango data and publishing it on ros topics.

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -472,7 +472,7 @@ TangoErrorType TangoRosNode::TangoSetupConfig() {
   }
 
   std::string datasets_path;
-  node_handle_.param(publisher_config_.datasets_path, datasets_path, std::string("/sdcard/tango_ros_streamer/datasets/"));
+  node_handle_.param(publisher_config_.datasets_path, datasets_path, DATASETS_PATH);
   const char* config_datasets_path = "config_datasets_path";
   result = TangoConfig_setString(tango_config_, config_datasets_path, datasets_path.c_str());
   if (result != TANGO_SUCCESS) {

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -470,6 +470,25 @@ TangoErrorType TangoRosNode::TangoSetupConfig() {
         << config_enable_color_camera << " error: " << result;
     return result;
   }
+
+  std::string datasets_path;
+  node_handle_.param(publisher_config_.datasets_path, datasets_path, std::string("/sdcard/tango_ros_streamer/datasets/"));
+  const char* config_datasets_path = "config_datasets_path";
+  result = TangoConfig_setString(tango_config_, config_datasets_path, datasets_path.c_str());
+  if (result != TANGO_SUCCESS) {
+    LOG(ERROR) << function_name << ", TangoConfig_setString "
+               << config_datasets_path << " error: " << result;
+    return result;
+  }
+  std::string dataset_uuid;
+  node_handle_.param(publisher_config_.dataset_uuid, dataset_uuid, std::string(""));
+  const char* config_experimental_load_dataset_UUID = "config_experimental_load_dataset_UUID";
+  result = TangoConfig_setString(tango_config_, config_experimental_load_dataset_UUID, dataset_uuid.c_str());
+  if (result != TANGO_SUCCESS) {
+    LOG(ERROR) << function_name << ", TangoConfig_setString "
+               << config_experimental_load_dataset_UUID << " error: " << result;
+    return result;
+  }
   return TANGO_SUCCESS;
 }
 


### PR DESCRIPTION
Allows to load and replay datasets from file system. Connect configuration in Tango looks like this:
```
I/tango   ( 1865): tango_context.cc:159 All config flag settings:
I/tango   ( 1865): {
I/tango   ( 1865): "config_datasets_path": "/sdcard/tango_ros_streamer/datasets/"
I/tango   ( 1865): "config_experimental_load_dataset_UUID": "c86dd05f-5cc9-4430-93e1-7a0fb9f474d2"
...
I/tango   ( 1865): }
```