### PR TITLE
Add map name and uuid in save map service response

### DIFF
--- a/tango_ros_common/tango_ros_messages/srv/SaveMap.srv
+++ b/tango_ros_common/tango_ros_messages/srv/SaveMap.srv
@@ -1,4 +1,6 @@
 string map_name
 ---
 string message
+string map_name
+string map_uuid
 bool success

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -1028,6 +1028,8 @@ bool TangoRosNode::SaveMap(tango_ros_messages::SaveMap::Request &req,
 
   std::string map_uuid_string = static_cast<std::string>(map_uuid);
   res.message =  "Map " + map_uuid_string + " successfully saved with the following name: " + map_name;
+  res.map_name = map_name;
+  res.map_uuid = map_uuid_string;
   res.success = true;
   tango_data_available_ = false;
   return true;


### PR DESCRIPTION
This PR adds the map name and uuid to the SaveMap service response.

Fixes #223.