### PR TITLE
Fix tango permission at first run

### DIFF
--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/RunningActivity.java
@@ -469,7 +469,7 @@ public class RunningActivity extends AppCompatRosActivity implements NodeletMana
         if (requestCode == REQUEST_CODE_TANGO_PERMISSION) {
             if (resultCode == RESULT_CANCELED) {
                 // No Tango permissions granted by the user.
-                finish();
+                displayToastMessage(R.string.tango_permission_denied);
             }
         }
     }

--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/RunningActivity.java
@@ -383,9 +383,6 @@ public class RunningActivity extends AppCompatRosActivity implements NodeletMana
                 getString(R.string.pref_log_file_default));
         setupUI();
         mLogger = new Logger(this, mLogTextView, TAGS_TO_LOG, logFileName, LOG_TEXT_MAX_LENGTH);
-
-        getTangoPermission(EXTRA_VALUE_ADF);
-        getTangoPermission(EXTRA_VALUE_DATASET);
     }
 
     @Override
@@ -453,6 +450,8 @@ public class RunningActivity extends AppCompatRosActivity implements NodeletMana
                 mLogger.setLogFileName(logFileName);
                 mLogger.start();
                 mCreateNewMap = mSharedPref.getBoolean(getString(R.string.pref_create_new_map_key), false);
+                getTangoPermission(EXTRA_VALUE_ADF);
+                getTangoPermission(EXTRA_VALUE_DATASET);
                 if (mCreateNewMap) {
                     mSaveButton.setVisibility(View.VISIBLE);
                 } else {
@@ -550,6 +549,8 @@ public class RunningActivity extends AppCompatRosActivity implements NodeletMana
         boolean appPreviouslyStarted = mSharedPref.getBoolean(getString(R.string.pref_previously_started_key), false);
         if (appPreviouslyStarted) {
             mLogger.start();
+            getTangoPermission(EXTRA_VALUE_ADF);
+            getTangoPermission(EXTRA_VALUE_DATASET);
             initAndStartRosJavaNode();
         } else {
             Intent intent = new Intent(this, SettingsActivity.class);

--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/SettingsActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/SettingsActivity.java
@@ -194,13 +194,15 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements
     }
 
     private void updateMapChooserPreference() {
-        MapChooserPreference mapChooserPreference =
-                (MapChooserPreference) mSettingsPreferenceFragment.findPreference(getString(R.string.pref_localization_map_uuid_key));
-
         SwitchPreference createNewMapPref = (SwitchPreference) mSettingsPreferenceFragment.findPreference(getString(R.string.pref_create_new_map_key));
+        if (createNewMapPref == null) return;
         boolean createNewMap = createNewMapPref.isChecked();
         ListPreference localizationModePref = (ListPreference) mSettingsPreferenceFragment.findPreference(getString(R.string.pref_localization_mode_key));
+        if (localizationModePref == null) return;
         String localizationMode = localizationModePref.getValue();
+        MapChooserPreference mapChooserPreference =
+                (MapChooserPreference) mSettingsPreferenceFragment.findPreference(getString(R.string.pref_localization_map_uuid_key));
+        if (mapChooserPreference == null) return;
         mapChooserPreference.setEnabled(!createNewMap && localizationMode.equals("3"));
 
         if (mUuidsNamesMap == null || mUuidsNamesMap.isEmpty()) {

--- a/TangoRosStreamer/app/src/main/res/values/strings.xml
+++ b/TangoRosStreamer/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="snackbar_text_restart_app">You will need to restart the app to apply these new settings</string>
     <string name="snackbar_text_restart_tango">You will need to restart Tango to apply these new settings</string>
     <string name="snackbar_action_text_restart_tango">RESTART TANGO</string>
+    <string name="tango_permission_denied">Be aware that you will not be able to use all functionalities from TangoRosStreamer</string>
 
     <string name="title_activity_about">About Tango Ros Streamer</string>
     <string name="description_activity_about">


### PR DESCRIPTION
This PR fixes 3 issues related to tango permision and first run:
* Fix app crash in SettingsActivity at first run
* For the first run, ask for Tango permissions only when going back to the RunningActivity
* If a Tango permission is not granted, display a toast message instead of finishing the app

Fixes #231.