### PR TITLE
Feature/update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ You can read the ROS wiki [here](http://wiki.ros.org/tango_ros_streamer).
 This work is developed by [Intermodalics](http://www.intermodalics.eu/) in collaboration with [Ekumen](http://www.ekumenlabs.com/) and [Google Tango](https://get.google.com/tango/).  
 Do not hesitate to give us feedback if something is broken or if you think it lacks some features. The best way to do this is by adding issues to this repository.
 
+# Known projects using TangoRosStreamer
+* [tangobot](https://github.com/ekumenlabs/tangobot/) : An android application to navigate with the [Turtlebot](http://www.turtlebot.com/) using Tango.
+
 # Kickstart
 The app is available in Google's Play Store: https://play.google.com/store/apps/details?id=eu.intermodalics.tango_ros_streamer  
 It can be installed on any Tango-enabled device. Note that the minimum Tango version required to run Tango Ros Streamer is Yildun (you will find the Tango release history [here](https://developers.google.com/tango/release-notes)). To check the Tango version of your device go to Settings->Apps->Tango Core. 
@@ -39,6 +42,7 @@ rosdep update
 echo "source /opt/ros/indigo/setup.bash" >> ~/.bashrc
 source ~/.bashrc
 sudo apt-get install ros-indigo-rosjava-build-tools
+sudo apt-get install ros-indigo-genjava
 ```
 Replace indigo by kinetic if you are using Ubuntu 16.04.
 
@@ -71,10 +75,7 @@ mkdir -p ~/tango_ros_ws/src
 cd ~/tango_ros_ws/src
 git clone --recursive git@github.com:Intermodalics/tango_ros.git
 cd ~/tango_ros_ws
-```  
-Then, you can build the app either with catkin or with Android Studio. Follow the instructions below corresponding to your prefered way.
-
-### Using catkin
+``` 
 
 Create a local.properties file
 ```
@@ -86,9 +87,13 @@ ndk.dir=/opt/android-ndk-r10b
 sdk.dir=/opt/android-sdk-linux
 ```
 
-Build the app and generate its .apk file.
+Install catkin tools if necessary.
 ```
 sudo apt-get install git python-catkin-tools
+```
+
+Build the app and generate its .apk file.
+```
 catkin build --no-jobserver
 ``` 
 
@@ -97,9 +102,11 @@ Plug your device to your desktop and install the app on your device using [adb](
 adb install -r -d ~/tango_ros_ws/src/tango_ros/TangoRosStreamer/app/build/outputs/apk/app-debug.apk
 ```
 
-### Using Android Studio
+# Developping with Android Studio
 
-#### Installation of Android Studio
+We recommend using Android Studio as a development tool. 
+
+## Installation of Android Studio
 The steps detailed below are based on this [installation guide](http://wiki.ros.org/android/kinetic/Android%20Studio/Download).
 
 For Android Studio we need Java, so let's install this first. On Ubuntu 14.04, we need to install openjdk-7-jdk, while on Ubuntu 16.04 we recommend to use openjdk-8-jdk instead.
@@ -128,9 +135,12 @@ sudo chown $(whoami) /opt/android-sdk
 echo export ANDROID_HOME=/opt/android-sdk >> ~/.bashrc
 ```
 
-Finally, launch Android Studio:
+## Building the app with Android Studio
+
+Launch Android Studio:
 ```
 source ~/.bashrc
+source ~/tango_ros_ws/devel/setup.bash
 studio.sh
 ```
 
@@ -142,7 +152,6 @@ echo "export PATH=\{$ANDROID_HOME}/ndk-bundle:\${PATH}" >> ~/.bashrc
 source ~/.bashrc
 ```
 
-#### Building the app
 In Android Studio, choose "Import project" and select the app folder (```~/tango_ros_ws/src/tango_ros/TangoRosStreamer```). 
 
 In your local.properties file check that the paths to your Android SDK and NDK are set properly. The Gradle set-up relies on the following variables that need to set up. This can be done using the auto-generated local.properties file or gradle properties in the HOME folder (~/.gradle/gradle.properties).  

--- a/tango_ros_common/tango_ros_messages/CMakeLists.txt
+++ b/tango_ros_common/tango_ros_messages/CMakeLists.txt
@@ -21,39 +21,10 @@ generate_messages(
 )
 
 catkin_package(
-  INCLUDE_DIRS include
   CATKIN_DEPENDS message_runtime std_msgs
   )
 
 include_directories(
-  include
   ${catkin_INCLUDE_DIRS}
 )
 
-# Copy generated header files by dynamic reconfigure, srv,... into local include folder.
-# Otherwise these header files can not be found when building for Android.
-set(file_names_to_copy
-  GetMapName
-  GetMapNameRequest
-  GetMapNameResponse
-  GetMapUuids
-  GetMapUuidsRequest
-  GetMapUuidsResponse
-  SaveMap
-  SaveMapRequest
-  SaveMapResponse
-  TangoConnect
-  TangoConnectRequest
-  TangoConnectResponse
-)
-set(generated_header_LOCATION  ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/)
-set(generated_header_DESTINATION ${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/)
-foreach(file_name ${file_names_to_copy})
-  set(from ${generated_header_LOCATION}${file_name}.h)
-  set(to ${generated_header_DESTINATION}${file_name}.h)
-  add_custom_command(
-    OUTPUT ${to}
-    DEPENDS ${from} ${${PROJECT_NAME}_EXPORTED_TARGETS}
-    COMMAND cmake -E copy ${from} ${to})
-  add_custom_target(copy_${file_name} ALL DEPENDS ${to})
-endforeach(file_name)

--- a/tango_ros_common/tango_ros_messages/include/README.txt
+++ b/tango_ros_common/tango_ros_messages/include/README.txt
@@ -1,2 +1,0 @@
-Empty directory.
-Some generated headers are copied here when building.

--- a/tango_ros_common/tango_ros_native/CMakeLists.txt
+++ b/tango_ros_common/tango_ros_native/CMakeLists.txt
@@ -56,25 +56,3 @@ install(TARGETS tango_ros_native
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
-
-# Copy generated header files by dynamic reconfigure, srv,... into local include folder.
-# Otherwise these header files can not be found when building for Android.
-set(file_names_to_copy
-  PublisherConfig
-)
-set(generated_header_LOCATION  ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/)
-set(generated_header_DESTINATION ${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/)
-foreach(file_name ${file_names_to_copy})
-  set(from ${generated_header_LOCATION}${file_name}.h)
-  set(to ${generated_header_DESTINATION}${file_name}.h)
-  add_custom_command(
-    OUTPUT ${to}
-    DEPENDS ${from}
-    COMMAND cmake -E copy ${from} ${to})
-  add_custom_target(copy_${file_name} ALL DEPENDS ${to})
-endforeach(file_name)
-
-if(CATKIN_ENABLE_TESTING)
-  catkin_add_gtest(${PROJECT_NAME}_test_tango_ros test/test_tango_ros_msg.cpp)
-  target_link_libraries(${PROJECT_NAME}_test_tango_ros tango_ros_native)
-endif()


### PR DESCRIPTION
This PR fixes #216.
It also fixes #86: by sourcing the devel space before launching Android Studio, copying the generated files to the source folder is not required anymore.