### PR TITLE
Fix/permission and getmaps ys

### DIFF
--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
@@ -122,6 +122,8 @@ public class RunningActivity extends AppCompatRosActivity implements TangoNodele
     private boolean mMapSaved = false;
     private HashMap<String, String> mUuidsNamesHashMap;
     private BroadcastReceiver mRestartTangoAlertReceiver;
+    private boolean mAdfPermissionHasBeenAsked = false;
+    private boolean mDatasetPermissionHasBeenAsked = false;
 
     // UI objects.
     private TextView mUriTextView;
@@ -495,7 +497,13 @@ public class RunningActivity extends AppCompatRosActivity implements TangoNodele
                 // No Tango permissions granted by the user.
                 displayToastMessage(R.string.tango_permission_denied);
             }
-            if (requestCode == REQUEST_CODE_DATASET_PERMISSION) {
+            if (requestCode == REQUEST_CODE_ADF_PERMISSION) {
+                mAdfPermissionHasBeenAsked = true;
+            }
+            if (requestCode ==  REQUEST_CODE_DATASET_PERMISSION) {
+                mDatasetPermissionHasBeenAsked = true;
+            }
+            if (mAdfPermissionHasBeenAsked && mDatasetPermissionHasBeenAsked) {
                 Log.i(TAG, "initAndStartRosJavaNode");
                 initAndStartRosJavaNode();
             }

--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
@@ -122,8 +122,10 @@ public class RunningActivity extends AppCompatRosActivity implements TangoNodele
     private boolean mMapSaved = false;
     private HashMap<String, String> mUuidsNamesHashMap;
     private BroadcastReceiver mRestartTangoAlertReceiver;
-    private boolean mAdfPermissionHasBeenAsked = false;
-    private boolean mDatasetPermissionHasBeenAsked = false;
+    // True after the user answered the ADF permission popup (the permission has not been necessarily granted).
+    private boolean mAdfPermissionHasBeenAnswered = false;
+    // True after the user answered the dataset permission popup (the permission has not been necessarily granted).
+    private boolean mDatasetPermissionHasBeenAnswered = false;
 
     // UI objects.
     private TextView mUriTextView;
@@ -498,12 +500,16 @@ public class RunningActivity extends AppCompatRosActivity implements TangoNodele
                 displayToastMessage(R.string.tango_permission_denied);
             }
             if (requestCode == REQUEST_CODE_ADF_PERMISSION) {
-                mAdfPermissionHasBeenAsked = true;
+                // The user answered the ADF permission popup (the permission has not been necessarily granted).
+                mAdfPermissionHasBeenAnswered = true;
             }
             if (requestCode ==  REQUEST_CODE_DATASET_PERMISSION) {
-                mDatasetPermissionHasBeenAsked = true;
+                // The user answered the dataset permission popup (the permission has not been necessarily granted).
+                mDatasetPermissionHasBeenAnswered = true;
             }
-            if (mAdfPermissionHasBeenAsked && mDatasetPermissionHasBeenAsked) {
+            if (mAdfPermissionHasBeenAnswered && mDatasetPermissionHasBeenAnswered) {
+                // Both ADF and dataset permissions popup have been answered by the user, the node
+                // can start.
                 Log.i(TAG, "initAndStartRosJavaNode");
                 initAndStartRosJavaNode();
             }

--- a/TangoRosStreamer/tango_ros_test/src/main/jni/test/tango_ros_api_test.cc
+++ b/TangoRosStreamer/tango_ros_test/src/main/jni/test/tango_ros_api_test.cc
@@ -26,7 +26,7 @@ std::string host_ip;
 
 class TangoRosTest : public ::testing::Test {
  public:
-  constexpr static int TEST_DURATION = 20; // in second.
+  constexpr static int TEST_DURATION = 60; // in second.
 };
 
 TEST_F(TangoRosTest, TestPublishingForFixedTime) {

--- a/TangoRosStreamer/tango_ros_test/src/main/jni/test/tango_ros_api_test.cc
+++ b/TangoRosStreamer/tango_ros_test/src/main/jni/test/tango_ros_api_test.cc
@@ -26,7 +26,7 @@ std::string host_ip;
 
 class TangoRosTest : public ::testing::Test {
  public:
-  constexpr static int TEST_DURATION = 60; // in second.
+  constexpr static int TEST_DURATION = 20; // in second.
 };
 
 TEST_F(TangoRosTest, TestPublishingForFixedTime) {

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -1179,14 +1179,8 @@ std::string TangoRosNode::GetAvailableMapUuidsList() {
     LOG(INFO) << "Error while retrieving all available map UUIDs, error: " << result;
     return "";
   }
-  if (uuid_list != NULL) {
-    LOG(INFO) << "uuid list is not null";
-    if (uuid_list[0] != '\0') {
-      LOG(INFO) << "UUID list: " << uuid_list;
-    } else {
-      LOG(ERROR) << "uuid_list[0] == \0";
-      return "";
-    }
+  if (uuid_list != NULL && uuid_list[0] != '\0') {
+    LOG(INFO) << "UUID list: " << uuid_list;
   } else {
     LOG(ERROR) << "No area description file available.";
     return "";

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -1176,7 +1176,7 @@ std::string TangoRosNode::GetAvailableMapUuidsList() {
   char* uuid_list;
   TangoErrorType result = TangoService_getAreaDescriptionUUIDList(&uuid_list);
   if (result != TANGO_SUCCESS) {
-    LOG(INFO) << "Error while retrieving all available map UUIDs, error: " << result;
+    LOG(ERROR) << "Error while retrieving all available map UUIDs, error: " << result;
     return "";
   }
   if (uuid_list != NULL && uuid_list[0] != '\0') {

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -1177,11 +1177,19 @@ std::string TangoRosNode::GetAvailableMapUuidsList() {
   TangoErrorType result = TangoService_getAreaDescriptionUUIDList(&uuid_list);
   if (result != TANGO_SUCCESS) {
     LOG(INFO) << "Error while retrieving all available map UUIDs, error: " << result;
+    return "";
   }
-  if (uuid_list != NULL && uuid_list[0] != '\0') {
-    LOG(INFO) << "UUID list: " << uuid_list;
+  if (uuid_list != NULL) {
+    LOG(INFO) << "uuid list is not null";
+    if (uuid_list[0] != '\0') {
+      LOG(INFO) << "UUID list: " << uuid_list;
+    } else {
+      LOG(ERROR) << "uuid_list[0] == \0";
+      return "";
+    }
   } else {
     LOG(ERROR) << "No area description file available.";
+    return "";
   }
   return std::string(uuid_list);
 }


### PR DESCRIPTION
This PR fixes two issues found while testing on YS:
* start the tango nodelet only after asking for tango permissions
* returning an empty string if there is no map on the device yet.