### PR TITLE
Allow to disable depth camera + move parameter node to tango_common

### DIFF
--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
@@ -67,7 +67,7 @@ import eu.intermodalics.nodelet_manager.TangoInitializationHelper.DefaultTangoSe
 import eu.intermodalics.tango_ros_common.Logger;
 import eu.intermodalics.tango_ros_common.TangoServiceClientNode;
 import eu.intermodalics.tango_ros_streamer.nodes.ImuNode;
-import eu.intermodalics.tango_ros_streamer.nodes.ParameterNode;
+import eu.intermodalics.tango_ros_common.ParameterNode;
 import eu.intermodalics.tango_ros_streamer.R;
 import eu.intermodalics.tango_ros_streamer.android.SaveMapDialog;
 import tango_ros_messages.TangoConnectRequest;
@@ -511,6 +511,7 @@ public class RunningActivity extends AppCompatRosActivity implements TangoNodele
         }
         HashMap<String, String> tangoConfigurationParameters = new HashMap<String, String>();
         tangoConfigurationParameters.put(getString(R.string.pref_create_new_map_key), "boolean");
+        tangoConfigurationParameters.put(getString(R.string.pref_enable_depth_key), "boolean");
         tangoConfigurationParameters.put(getString(R.string.pref_localization_mode_key), "int_as_string");
         tangoConfigurationParameters.put(getString(R.string.pref_localization_map_uuid_key), "string");
         mParameterNode = new ParameterNode(this, tangoConfigurationParameters);

--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/SettingsActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/SettingsActivity.java
@@ -119,6 +119,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements
         if (key == getString(R.string.pref_master_is_local_key) ||
                 key == getString(R.string.pref_master_uri_key) ||
                 key == getString(R.string.pref_create_new_map_key) ||
+                key == getString(R.string.pref_enable_depth_key) ||
                 key == getString(R.string.pref_localization_mode_key) ||
                 key == getString(R.string.pref_localization_map_uuid_key)) {
             boolean previouslyStarted = mSharedPref.getBoolean(getString(R.string.pref_previously_started_key), false);
@@ -133,8 +134,9 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements
                 }
                 // These changes require to restart Tango only.
                 if (key == getString(R.string.pref_create_new_map_key) ||
-                        key == getString(R.string.pref_localization_mode_key) ||
-                        key == getString(R.string.pref_localization_map_uuid_key)) {
+                    key == getString(R.string.pref_enable_depth_key) ||
+                    key == getString(R.string.pref_localization_mode_key) ||
+                    key == getString(R.string.pref_localization_map_uuid_key)) {
                     Snackbar snackbar = Snackbar.make(mSettingsPreferenceFragment.getView(), getString(R.string.snackbar_text_restart_tango), Snackbar.LENGTH_INDEFINITE);
                     snackbar.setAction(getString(R.string.snackbar_action_text_restart_tango), new View.OnClickListener() {
                         @Override

--- a/TangoRosStreamer/app/src/main/res/values/strings.xml
+++ b/TangoRosStreamer/app/src/main/res/values/strings.xml
@@ -75,7 +75,7 @@
     <string name="pref_create_new_map_summary">Enable to create a new localization map. This map can be used for localization later.</string>
 
     <string name="pref_enable_depth">Enable depth camera</string>
-    <string name="pref_enable_depth_key">enable_depth_camera</string>
+    <string name="pref_enable_depth_key">enable_depth</string>
     <string name="pref_enable_depth_summary">Enable depth camera when connecting to Tango.</string>
 
     <string name="pref_localization_mode_key">localization_mode</string>

--- a/TangoRosStreamer/app/src/main/res/values/strings.xml
+++ b/TangoRosStreamer/app/src/main/res/values/strings.xml
@@ -74,6 +74,10 @@
     <string name="pref_create_new_map_key">create_new_map</string>
     <string name="pref_create_new_map_summary">Enable to create a new localization map. This map can be used for localization later.</string>
 
+    <string name="pref_enable_depth">Enable depth camera</string>
+    <string name="pref_enable_depth_key">enable_depth_camera</string>
+    <string name="pref_enable_depth_summary">Enable depth camera when connecting to Tango.</string>
+
     <string name="pref_localization_mode_key">localization_mode</string>
     <string name="pref_localization_map_uuid_key">localization_map_uuid</string>
 

--- a/TangoRosStreamer/app/src/main/res/xml/pref_settings.xml
+++ b/TangoRosStreamer/app/src/main/res/xml/pref_settings.xml
@@ -39,6 +39,12 @@
         <eu.intermodalics.tango_ros_streamer.android.MapChooserPreference
             android:title="Choose localization map"
             android:key="@string/pref_localization_map_uuid_key" />
+        <SwitchPreference
+            android:title="@string/pref_enable_depth"
+            android:key="@string/pref_enable_depth_key"
+            android:defaultValue="true"
+            android:disableDependentsState="true"
+            android:summary="@string/pref_enable_depth_summary" />
     </PreferenceCategory>
 
 

--- a/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
+++ b/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package eu.intermodalics.tango_ros_streamer.nodes;
+package eu.intermodalics.tango_ros_common;
 
 import android.app.Activity;
 import android.content.SharedPreferences;

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
@@ -77,6 +77,7 @@ const std::string LOCALIZATION_MAP_UUID_PARAM_NAME = "localization_map_uuid";
 const std::string DATASET_PATH_PARAM_NAME = "dataset_datasets_path";
 const std::string DATASET_UUID_PARAM_NAME = "dataset_uuid";
 const std::string USE_FLOOR_PLAN_PARAM_NAME = "use_floor_plan";
+const std::string ENABLE_DEPTH = "enable_depth";
 const std::string PUBLISH_POSE_ON_TF_PARAM_NAME = "publish_pose_on_tf";
 const std::string PUBLISH_POSE_ON_TOPIC_PARAM_NAME = "publish_pose_on_topic";
 

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
@@ -209,6 +209,7 @@ class TangoRosNode : public ::nodelet::Nodelet {
   double time_offset_ = 0.; // Offset between tango time and ros time in s.
   bool publish_pose_on_tf_ = false;
   bool publish_pose_on_topic_ = false;
+  bool enable_depth_ = true;
 
   tf::TransformBroadcaster tf_broadcaster_;
   ros::Publisher start_of_service_T_device_publisher_;

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -351,7 +351,9 @@ TangoErrorType TangoRosNode::TangoSetupConfig() {
     return result;
   }
   const char* config_enable_depth = "config_enable_depth";
-  result = TangoConfig_setBool(tango_config_, config_enable_depth, true);
+  bool enable_depth;
+  node_handle_.param<bool>(ENABLE_DEPTH, enable_depth, true);
+  result = TangoConfig_setBool(tango_config_, config_enable_depth, enable_depth);
   if (result != TANGO_SUCCESS) {
     LOG(ERROR) << function_name << ", TangoConfig_setBool "
         << config_enable_depth << " error: " << result;

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -239,6 +239,11 @@ void TangoRosNode::onInit() {
   } else {
     node_handle_.setParam(PUBLISH_POSE_ON_TOPIC_PARAM_NAME, false);
   }
+  if (node_handle_.hasParam(ENABLE_DEPTH)) {
+    node_handle_.param(ENABLE_DEPTH, enable_depth_, true);
+  } else {
+    node_handle_.setParam(ENABLE_DEPTH, true);
+  }
 }
 
 TangoRosNode::~TangoRosNode() {
@@ -351,9 +356,8 @@ TangoErrorType TangoRosNode::TangoSetupConfig() {
     return result;
   }
   const char* config_enable_depth = "config_enable_depth";
-  bool enable_depth;
-  node_handle_.param<bool>(ENABLE_DEPTH, enable_depth, true);
-  result = TangoConfig_setBool(tango_config_, config_enable_depth, enable_depth);
+  node_handle_.param<bool>(ENABLE_DEPTH, enable_depth_, true);
+  result = TangoConfig_setBool(tango_config_, config_enable_depth, enable_depth_);
   if (result != TANGO_SUCCESS) {
     LOG(ERROR) << function_name << ", TangoConfig_setBool "
         << config_enable_depth << " error: " << result;


### PR DESCRIPTION
Allows to enable/disable the depth camera using Settings Activity or the ROS parameter server.

The PR also moves the parameter node to the tango_ros_common module since it is written in a generic way and can be reused in other Tango-ROS apps.