### PR TITLE
Switch preference has bugs in Android 4.4

### DIFF
--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/android/CustomSwitchPreference.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/android/CustomSwitchPreference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Intermodalics All Rights Reserved.
+ * Copyright 2017 Intermodalics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/android/CustomSwitchPreference.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/android/CustomSwitchPreference.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 Intermodalics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.intermodalics.tango_ros_streamer.android;
+
+import android.content.Context;
+import android.preference.SwitchPreference;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Switch;
+
+/*
+ * This CustomSwitchPreference is a workaround for the SwitchPreference bug in Android 4.4
+ * (version used by the Tango Development Kit device): having multiple SwitchPreference is not
+ * working properly in this Android version, i.e. when switching one preference the other one also
+ * switches.
+ * source:
+ * http://stackoverflow.com/questions/17664259/android-switchpreference-not-working-correctly-in-4-2-2
+ */
+public class CustomSwitchPreference extends SwitchPreference {
+
+    /**
+     * Construct a new SwitchPreference with the given style options.
+     *
+     * @param context The Context that will style this preference
+     * @param attrs Style attributes that differ from the default
+     * @param defStyle Theme attribute defining the default style options
+     */
+    public CustomSwitchPreference(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    /**
+     * Construct a new SwitchPreference with the given style options.
+     *
+     * @param context The Context that will style this preference
+     * @param attrs Style attributes that differ from the default
+     */
+    public CustomSwitchPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    /**
+     * Construct a new SwitchPreference with default style options.
+     *
+     * @param context The Context that will style this preference
+     */
+    public CustomSwitchPreference(Context context) {
+        super(context, null);
+    }
+
+    @Override
+    protected void onBindView(View view) {
+        // Clean listener before invoke SwitchPreference.onBindView
+        ViewGroup viewGroup= (ViewGroup)view;
+        clearListenerInViewGroup(viewGroup);
+        super.onBindView(view);
+    }
+
+    /**
+     * Clear listener in Switch for specify ViewGroup.
+     *
+     * @param viewGroup The ViewGroup that will need to clear the listener.
+     */
+    private void clearListenerInViewGroup(ViewGroup viewGroup) {
+        if (null == viewGroup) {
+            return;
+        }
+
+        int count = viewGroup.getChildCount();
+        for(int n = 0; n < count; ++n) {
+            View childView = viewGroup.getChildAt(n);
+            if(childView instanceof Switch) {
+                final Switch switchView = (Switch) childView;
+                switchView.setOnCheckedChangeListener(null);
+                return;
+            } else if (childView instanceof ViewGroup){
+                ViewGroup childGroup = (ViewGroup)childView;
+                clearListenerInViewGroup(childGroup);
+            }
+        }
+    }
+
+}

--- a/TangoRosStreamer/app/src/main/res/xml/pref_settings.xml
+++ b/TangoRosStreamer/app/src/main/res/xml/pref_settings.xml
@@ -39,11 +39,14 @@
         <eu.intermodalics.tango_ros_streamer.android.MapChooserPreference
             android:title="Choose localization map"
             android:key="@string/pref_localization_map_uuid_key" />
-        <SwitchPreference
+        <!-- Use CheckBoxPreference rather than SwitchPreference,
+        having multiple SwitchPreference is not working properly in Android 4.4.2
+        (version used by the Tango Development Kit device):
+        http://stackoverflow.com/questions/17664259/android-switchpreference-not-working-correctly-in-4-2-2 -->
+        <CheckBoxPreference
             android:title="@string/pref_enable_depth"
             android:key="@string/pref_enable_depth_key"
             android:defaultValue="true"
-            android:disableDependentsState="true"
             android:summary="@string/pref_enable_depth_summary" />
     </PreferenceCategory>
 

--- a/TangoRosStreamer/app/src/main/res/xml/pref_settings.xml
+++ b/TangoRosStreamer/app/src/main/res/xml/pref_settings.xml
@@ -23,7 +23,7 @@
     <PreferenceCategory
         android:title="@string/pref_category_tango_title"
         android:key="@string/pref_category_tango_key">
-        <SwitchPreference
+        <eu.intermodalics.tango_ros_streamer.android.CustomSwitchPreference
             android:title="@string/pref_create_new_map"
             android:key="@string/pref_create_new_map_key"
             android:defaultValue="false"
@@ -39,11 +39,7 @@
         <eu.intermodalics.tango_ros_streamer.android.MapChooserPreference
             android:title="Choose localization map"
             android:key="@string/pref_localization_map_uuid_key" />
-        <!-- Use CheckBoxPreference rather than SwitchPreference,
-        having multiple SwitchPreference is not working properly in Android 4.4.2
-        (version used by the Tango Development Kit device):
-        http://stackoverflow.com/questions/17664259/android-switchpreference-not-working-correctly-in-4-2-2 -->
-        <CheckBoxPreference
+        <eu.intermodalics.tango_ros_streamer.android.CustomSwitchPreference
             android:title="@string/pref_enable_depth"
             android:key="@string/pref_enable_depth_key"
             android:defaultValue="true"


### PR DESCRIPTION
This PR replaces the SwitchPreference which enables the depth camera by a checkbox. The reason is that having multiple SwitchPreferences has a bug in Android 4.4 (Tango Development Kit device), i.e. when switching one preference the other one also switches.

Source: https://issuetracker.google.com/issues/36941388