### PR TITLE
Adds enable color setting and fixes sync between settings activity and ROS parameter server

### DIFF
--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
@@ -20,10 +20,7 @@ import android.animation.AnimatorInflater;
 import android.animation.AnimatorSet;
 import android.app.DialogFragment;
 import android.app.FragmentManager;
-import android.content.BroadcastReceiver;
-import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.net.Uri;
@@ -92,12 +89,12 @@ public class RunningActivity extends AppCompatRosActivity implements
     private static final String EXTRA_VALUE_DATASET = "DATASET_PERMISSION";
     private static final int REQUEST_CODE_ADF_PERMISSION = 111;
     private static final int REQUEST_CODE_DATASET_PERMISSION = 112;
+    public static final String RESTART_TANGO = "restart_tango";
 
-    public static class startSettingsActivityRequest {
+    public static class StartSettingsActivityRequest {
         public static final int FIRST_RUN = 11;
         public static final int STANDARD_RUN = 12;
     }
-    public static final String RESTART_TANGO_ALERT = "restart_tango_alert";
 
     enum RosStatus {
         UNKNOWN,
@@ -127,7 +124,6 @@ public class RunningActivity extends AppCompatRosActivity implements
     private boolean mCreateNewMap = false;
     private boolean mMapSaved = false;
     private HashMap<String, String> mUuidsNamesHashMap;
-    private BroadcastReceiver mRestartTangoAlertReceiver;
     // True after the user answered the ADF permission popup (the permission has not been necessarily granted).
     private boolean mAdfPermissionHasBeenAnswered = false;
     // True after the user answered the dataset permission popup (the permission has not been necessarily granted).
@@ -408,6 +404,7 @@ public class RunningActivity extends AppCompatRosActivity implements
         for (int i = 0; i < mapUuids.size(); ++i) {
             mUuidsNamesHashMap.put(mapUuids.get(i), mapNames.get(i));
         }
+        if(mParameterNode != null) mParameterNode.setPreferencesFromParameterServer();
         Intent settingsActivityIntent = new Intent(SettingsActivity.NEW_UUIDS_NAMES_MAP_ALERT);
         settingsActivityIntent.putExtra(getString(R.string.uuids_names_map), mUuidsNamesHashMap);
         this.sendBroadcast(settingsActivityIntent);
@@ -421,7 +418,7 @@ public class RunningActivity extends AppCompatRosActivity implements
         }
         if (status == TangoStatus.SERVICE_CONNECTED.ordinal() && mTangoStatus != TangoStatus.SERVICE_CONNECTED) {
             saveUuidsNamestoHashMap();
-            mParameterNode.syncLocalPreferencesWithParameterServer();
+            mParameterNode.setPreferencesFromParameterServer();
             mMapSaved = false;
             if (mSnackbarLoadNewMap != null && mSnackbarLoadNewMap.isShown()) {
                 mSnackbarLoadNewMap.dismiss();
@@ -445,13 +442,6 @@ public class RunningActivity extends AppCompatRosActivity implements
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mRestartTangoAlertReceiver = new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                restartTango();
-            }
-        };
-        this.registerReceiver(this.mRestartTangoAlertReceiver, new IntentFilter(RESTART_TANGO_ALERT));
         mSharedPref = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
         mRunLocalMaster = mSharedPref.getBoolean(getString(R.string.pref_master_is_local_key), false);
         mMasterUri = mSharedPref.getString(getString(R.string.pref_master_uri_key),
@@ -485,9 +475,10 @@ public class RunningActivity extends AppCompatRosActivity implements
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.settings:
+                if(mParameterNode != null) mParameterNode.setPreferencesFromParameterServer();
                 Intent settingsActivityIntent = new Intent(this, SettingsActivity.class);
                 settingsActivityIntent.putExtra(getString(R.string.uuids_names_map), mUuidsNamesHashMap);
-                startActivityForResult(settingsActivityIntent, startSettingsActivityRequest.STANDARD_RUN);
+                startActivityForResult(settingsActivityIntent, StartSettingsActivityRequest.STANDARD_RUN);
                 return true;
             case R.id.share:
                 mLogger.saveLogToFile();
@@ -512,15 +503,25 @@ public class RunningActivity extends AppCompatRosActivity implements
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        if (mParameterNode != null) mParameterNode.syncLocalPreferencesWithParameterServer();
+        if (mParameterNode != null) mParameterNode.setPreferencesFromParameterServer();
         this.nodeMainExecutorService.forceShutdown();
-        this.unregisterReceiver(mRestartTangoAlertReceiver);
     }
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (resultCode == RESULT_CANCELED) { // Result code returned when back button is pressed.
-            if (requestCode == startSettingsActivityRequest.FIRST_RUN) {
+            // Upload new settings to parameter server.
+            if ((requestCode == StartSettingsActivityRequest.STANDARD_RUN ||
+                    requestCode == StartSettingsActivityRequest.FIRST_RUN) &&
+                    mParameterNode != null) {
+                mParameterNode.uploadPreferencesToParameterServer();
+            }
+
+            if (data != null && data.getBooleanExtra(RESTART_TANGO, false)) {
+                restartTango();
+            }
+
+            if (requestCode == StartSettingsActivityRequest.FIRST_RUN) {
                 mRunLocalMaster = mSharedPref.getBoolean(getString(R.string.pref_master_is_local_key), false);
                 mMasterUri = mSharedPref.getString(getString(R.string.pref_master_uri_key),
                         getResources().getString(R.string.pref_master_uri_default));
@@ -532,7 +533,7 @@ public class RunningActivity extends AppCompatRosActivity implements
                 getTangoPermission(EXTRA_VALUE_ADF, REQUEST_CODE_ADF_PERMISSION);
                 getTangoPermission(EXTRA_VALUE_DATASET, REQUEST_CODE_DATASET_PERMISSION);
                 updateSaveMapButton();
-            } else if (requestCode == startSettingsActivityRequest.STANDARD_RUN) {
+            } else if (requestCode == StartSettingsActivityRequest.STANDARD_RUN) {
                 // It is ok to change the log file name at runtime.
                 String logFileName = mSharedPref.getString(getString(R.string.pref_log_file_key),
                         getString(R.string.pref_log_file_default));
@@ -596,7 +597,7 @@ public class RunningActivity extends AppCompatRosActivity implements
     }
 
     private void restartTango() {
-        mParameterNode.syncLocalPreferencesWithParameterServer();
+        if (mParameterNode != null) mParameterNode.setPreferencesFromParameterServer();
         updateSaveMapButton();
         mTangoServiceClientNode.callTangoConnectService(TangoConnectRequest.RECONNECT);
     }
@@ -691,7 +692,7 @@ public class RunningActivity extends AppCompatRosActivity implements
             getTangoPermission(EXTRA_VALUE_DATASET, REQUEST_CODE_DATASET_PERMISSION);
         } else {
             Intent intent = new Intent(this, SettingsActivity.class);
-            startActivityForResult(intent, startSettingsActivityRequest.FIRST_RUN);
+            startActivityForResult(intent, StartSettingsActivityRequest.FIRST_RUN);
         }
     }
 

--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
@@ -421,7 +421,7 @@ public class RunningActivity extends AppCompatRosActivity implements
         }
         if (status == TangoStatus.SERVICE_CONNECTED.ordinal() && mTangoStatus != TangoStatus.SERVICE_CONNECTED) {
             saveUuidsNamestoHashMap();
-            mParameterNode.setPreferencesFromParameterServer();
+            mParameterNode.syncLocalPreferencesWithParameterServer();
             mMapSaved = false;
             if (mSnackbarLoadNewMap != null && mSnackbarLoadNewMap.isShown()) {
                 mSnackbarLoadNewMap.dismiss();
@@ -512,6 +512,7 @@ public class RunningActivity extends AppCompatRosActivity implements
     @Override
     protected void onDestroy() {
         super.onDestroy();
+        if (mParameterNode != null) mParameterNode.syncLocalPreferencesWithParameterServer();
         this.nodeMainExecutorService.forceShutdown();
         this.unregisterReceiver(mRestartTangoAlertReceiver);
     }
@@ -595,7 +596,7 @@ public class RunningActivity extends AppCompatRosActivity implements
     }
 
     private void restartTango() {
-        mParameterNode.uploadPreferencesToParameterServer();
+        mParameterNode.syncLocalPreferencesWithParameterServer();
         updateSaveMapButton();
         mTangoServiceClientNode.callTangoConnectService(TangoConnectRequest.RECONNECT);
     }

--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
@@ -619,6 +619,7 @@ public class RunningActivity extends AppCompatRosActivity implements
         HashMap<String, String> tangoConfigurationParameters = new HashMap<String, String>();
         tangoConfigurationParameters.put(getString(R.string.pref_create_new_map_key), "boolean");
         tangoConfigurationParameters.put(getString(R.string.pref_enable_depth_key), "boolean");
+        tangoConfigurationParameters.put(getString(R.string.pref_enable_color_camera_key), "boolean");
         tangoConfigurationParameters.put(getString(R.string.pref_localization_mode_key), "int_as_string");
         tangoConfigurationParameters.put(getString(R.string.pref_localization_map_uuid_key), "string");
         mParameterNode = new ParameterNode(this, tangoConfigurationParameters);

--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/SettingsActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/SettingsActivity.java
@@ -120,6 +120,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements
                 key == getString(R.string.pref_master_uri_key) ||
                 key == getString(R.string.pref_create_new_map_key) ||
                 key == getString(R.string.pref_enable_depth_key) ||
+                key == getString(R.string.pref_enable_color_camera_key) ||
                 key == getString(R.string.pref_localization_mode_key) ||
                 key == getString(R.string.pref_localization_map_uuid_key)) {
             boolean previouslyStarted = mSharedPref.getBoolean(getString(R.string.pref_previously_started_key), false);
@@ -139,6 +140,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements
                 // These changes require to restart Tango only.
                 if (key == getString(R.string.pref_create_new_map_key) ||
                     key == getString(R.string.pref_enable_depth_key) ||
+                    key == getString(R.string.pref_enable_color_camera_key) ||
                     key == getString(R.string.pref_localization_mode_key) ||
                     key == getString(R.string.pref_localization_map_uuid_key)) {
                     Snackbar snackbar = Snackbar.make(mSettingsPreferenceFragment.getView(),

--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/SettingsActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/SettingsActivity.java
@@ -177,7 +177,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements
             public void onReceive(Context context, Intent intent) {
                 mUuidsNamesMap = (HashMap<String, String>) intent.getSerializableExtra(getString(R.string.uuids_names_map));
                 updateMapChooserPreference();
-                mSettingsPreferenceFragment.setPreferencesSummury();
+                mSettingsPreferenceFragment.setPreferencesSummary();
             }
         };
         this.registerReceiver(this.mNewUuidsNamesMapAlertReceiver, new IntentFilter(NEW_UUIDS_NAMES_MAP_ALERT));
@@ -198,6 +198,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements
             snackbar.setAction(getString(R.string.snackbar_action_text_first_run), new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
+                    setResult(RESULT_CANCELED, getIntent().putExtra(RunningActivity.RESTART_TANGO, false));
                     onBackPressed();
                 }
             });
@@ -215,7 +216,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements
         Intent intent = getIntent();
         mUuidsNamesMap = (HashMap<String, String>) intent.getSerializableExtra(getString(R.string.uuids_names_map));
         updateMapChooserPreference();
-        mSettingsPreferenceFragment.setPreferencesSummury();
+        mSettingsPreferenceFragment.setPreferencesSummary();
     }
 
     @Override
@@ -268,7 +269,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements
         // to their values. When their values change, their summaries are
         // updated to reflect the new value, per the Android Design
         // guidelines.
-        public void setPreferencesSummury() {
+        public void setPreferencesSummary() {
             bindPreferenceSummaryToValue(findPreference(getResources().getString(R.string.pref_master_uri_key)));
             bindPreferenceSummaryToValue(findPreference(getResources().getString(R.string.pref_log_file_key)));
             bindPreferenceSummaryToValue(findPreference(getResources().getString(R.string.pref_localization_mode_key)));
@@ -292,9 +293,11 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements
         startActivity(intent);
     }
 
+    /**
+     * Returns to Running Acitivity and restart Tango.
+     */
     private void restartTango() {
-        Intent intent = new Intent(RunningActivity.RESTART_TANGO_ALERT);
-        this.sendBroadcast(intent);
+        setResult(RESULT_CANCELED, getIntent().putExtra(RunningActivity.RESTART_TANGO, true));
         onBackPressed();
     }
 }

--- a/TangoRosStreamer/app/src/main/res/values/strings.xml
+++ b/TangoRosStreamer/app/src/main/res/values/strings.xml
@@ -67,6 +67,10 @@
     <string name="pref_enable_depth_key">enable_depth</string>
     <string name="pref_enable_depth_summary">Enable depth camera when connecting to Tango.</string>
 
+    <string name="pref_enable_color_camera">Enable color camera</string>
+    <string name="pref_enable_color_camera_key">enable_color_camera</string>
+    <string name="pref_enable_color_camera_summary">Enable color camera when connecting to Tango.</string>
+
     <string name="pref_localization_mode_key">localization_mode</string>
     <string name="pref_localization_map_uuid_key">localization_map_uuid</string>
 

--- a/TangoRosStreamer/app/src/main/res/values/strings.xml
+++ b/TangoRosStreamer/app/src/main/res/values/strings.xml
@@ -69,7 +69,7 @@
 
     <string name="pref_enable_color_camera">Enable color camera</string>
     <string name="pref_enable_color_camera_key">enable_color_camera</string>
-    <string name="pref_enable_color_camera_summary">Enable color camera when connecting to Tango.</string>
+    <string name="pref_enable_color_camera_summary">Enable color camera when connecting to Tango. (Requires API > 23.)</string>
 
     <string name="pref_localization_mode_key">localization_mode</string>
     <string name="pref_localization_map_uuid_key">localization_map_uuid</string>

--- a/TangoRosStreamer/app/src/main/res/xml/pref_settings.xml
+++ b/TangoRosStreamer/app/src/main/res/xml/pref_settings.xml
@@ -44,6 +44,11 @@
             android:key="@string/pref_enable_depth_key"
             android:defaultValue="true"
             android:summary="@string/pref_enable_depth_summary" />
+        <eu.intermodalics.tango_ros_streamer.android.CustomSwitchPreference
+            android:title="@string/pref_enable_color_camera"
+            android:key="@string/pref_enable_color_camera_key"
+            android:defaultValue="true"
+            android:summary="@string/pref_enable_color_camera_summary" />
     </PreferenceCategory>
 
 

--- a/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
+++ b/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
@@ -61,6 +61,7 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
         mConnectedNode = connectedNode;
         mLog = connectedNode.getLog();
         setPreferencesFromParameterServer();
+        uploadPreferencesToParameterServer();
     }
 
     // Set ROS params according to preferences.

--- a/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
+++ b/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
@@ -60,12 +60,16 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
         mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(mCreatorActivity);
         mConnectedNode = connectedNode;
         mLog = connectedNode.getLog();
+        syncLocalPreferencesWithParameterServer();
+    }
+
+    public void syncLocalPreferencesWithParameterServer() {
         setPreferencesFromParameterServer();
         uploadPreferencesToParameterServer();
     }
 
     // Set ROS params according to preferences.
-    public void uploadPreferencesToParameterServer() {
+    private void uploadPreferencesToParameterServer() {
         for (String paramName : mParamNames.keySet()) {
             if (mParamNames.get(paramName) == "boolean") {
                 Boolean booleanValue = mSharedPreferences.getBoolean(paramName, false);
@@ -83,7 +87,7 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
     }
 
     // Set app preferences according to ROS params.
-    public void setPreferencesFromParameterServer() {
+    private void setPreferencesFromParameterServer() {
         SharedPreferences.Editor editor = mSharedPreferences.edit();
         for (String paramName : mParamNames.keySet()) {
             if (mParamNames.get(paramName) == "boolean") {

--- a/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
+++ b/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
@@ -63,31 +63,39 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
         syncLocalPreferencesWithParameterServer();
     }
 
+    /**
+     * First download ROS parameters from parameter server, then upload local settings to parameter
+     * server.
+     */
     public void syncLocalPreferencesWithParameterServer() {
         setPreferencesFromParameterServer();
         uploadPreferencesToParameterServer();
     }
 
     // Set ROS params according to preferences.
-    private void uploadPreferencesToParameterServer() {
+    public void uploadPreferencesToParameterServer() {
+        mLog.info("Upload preferences to parameter server.");
         for (String paramName : mParamNames.keySet()) {
-            if (mParamNames.get(paramName) == "boolean") {
-                Boolean booleanValue = mSharedPreferences.getBoolean(paramName, false);
-                mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), booleanValue);
-            }
-            if (mParamNames.get(paramName) == "int_as_string") {
-                String stringValue = mSharedPreferences.getString(paramName, "0");
-                mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), Integer.parseInt(stringValue));
-            }
-            if (mParamNames.get(paramName) == "string") {
-                String stringValue = mSharedPreferences.getString(paramName, "");
-                mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), stringValue);
-            }
+            uploadPreferenceToParameterServer(paramName);
+        }
+    }
+
+    public void uploadPreferenceToParameterServer(String paramName) {
+        String valueType = mParamNames.get(paramName);
+        if (valueType == "boolean") {
+            Boolean booleanValue = mSharedPreferences.getBoolean(paramName, false);
+            mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), booleanValue);
+        } else if (valueType == "int_as_string") {
+            String stringValue = mSharedPreferences.getString(paramName, "0");
+            mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), Integer.parseInt(stringValue));
+        } else if (valueType == "string") {
+            String stringValue = mSharedPreferences.getString(paramName, "");
+            mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), stringValue);
         }
     }
 
     // Set app preferences according to ROS params.
-    private void setPreferencesFromParameterServer() {
+    public void setPreferencesFromParameterServer() {
         SharedPreferences.Editor editor = mSharedPreferences.edit();
         for (String paramName : mParamNames.keySet()) {
             if (mParamNames.get(paramName) == "boolean") {

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
@@ -78,6 +78,7 @@ const std::string DATASET_PATH_PARAM_NAME = "dataset_datasets_path";
 const std::string DATASET_UUID_PARAM_NAME = "dataset_uuid";
 const std::string USE_FLOOR_PLAN_PARAM_NAME = "use_floor_plan";
 const std::string ENABLE_DEPTH = "enable_depth";
+const std::string ENABLE_COLOR_CAMERA = "enable_color";
 const std::string PUBLISH_POSE_ON_TF_PARAM_NAME = "publish_pose_on_tf";
 const std::string PUBLISH_POSE_ON_TOPIC_PARAM_NAME = "publish_pose_on_topic";
 
@@ -210,6 +211,7 @@ class TangoRosNode : public ::nodelet::Nodelet {
   bool publish_pose_on_tf_ = false;
   bool publish_pose_on_topic_ = false;
   bool enable_depth_ = true;
+  bool enable_color_camera_ = true;
 
   tf::TransformBroadcaster tf_broadcaster_;
   ros::Publisher start_of_service_T_device_publisher_;

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
@@ -78,7 +78,7 @@ const std::string DATASET_PATH_PARAM_NAME = "dataset_datasets_path";
 const std::string DATASET_UUID_PARAM_NAME = "dataset_uuid";
 const std::string USE_FLOOR_PLAN_PARAM_NAME = "use_floor_plan";
 const std::string ENABLE_DEPTH = "enable_depth";
-const std::string ENABLE_COLOR_CAMERA = "enable_color";
+const std::string ENABLE_COLOR_CAMERA = "enable_color_camera";
 const std::string PUBLISH_POSE_ON_TF_PARAM_NAME = "publish_pose_on_tf";
 const std::string PUBLISH_POSE_ON_TOPIC_PARAM_NAME = "publish_pose_on_topic";
 

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -231,18 +231,15 @@ void TangoRosNode::onInit() {
   }
   if (node_handle_.hasParam(PUBLISH_POSE_ON_TF_PARAM_NAME)) {
     node_handle_.param(PUBLISH_POSE_ON_TF_PARAM_NAME, publish_pose_on_tf_, true);
-  } else {
-    node_handle_.setParam(PUBLISH_POSE_ON_TF_PARAM_NAME, true);
   }
   if (node_handle_.hasParam(PUBLISH_POSE_ON_TOPIC_PARAM_NAME)) {
     node_handle_.param(PUBLISH_POSE_ON_TOPIC_PARAM_NAME, publish_pose_on_topic_, false);
-  } else {
-    node_handle_.setParam(PUBLISH_POSE_ON_TOPIC_PARAM_NAME, false);
   }
   if (node_handle_.hasParam(ENABLE_DEPTH)) {
     node_handle_.param(ENABLE_DEPTH, enable_depth_, true);
-  } else {
-    node_handle_.setParam(ENABLE_DEPTH, true);
+  }
+  if (node_handle_.hasParam(ENABLE_COLOR_CAMERA)) {
+    node_handle_.param(ENABLE_COLOR_CAMERA, enable_color_camera_, true);
   }
 }
 

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -368,7 +368,8 @@ TangoErrorType TangoRosNode::TangoSetupConfig() {
     return result;
   }
   const char* config_enable_color_camera = "config_enable_color_camera";
-  result = TangoConfig_setBool(tango_config_, config_enable_color_camera, true);
+  node_handle_.param<bool>(ENABLE_COLOR_CAMERA, enable_color_camera_, true);
+  result = TangoConfig_setBool(tango_config_, config_enable_color_camera, enable_color_camera_);
   if (result != TANGO_SUCCESS) {
     LOG(ERROR) << function_name << ", TangoConfig_setBool "
         << config_enable_color_camera << " error: " << result;

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -821,10 +821,10 @@ void TangoRosNode::PublishDevicePose() {
       std::unique_lock<std::mutex> lock(device_pose_thread_.data_available_mutex);
       device_pose_thread_.data_available.wait(lock);
       if (publish_pose_on_tf_) {
-        tf_broadcaster_.sendTransform(start_of_service_T_device_);
+        tf_static_broadcaster_.sendTransform(start_of_service_T_device_);
         if (area_description_T_start_of_service_.child_frame_id != "") {
           // This transform can be empty. Don't publish it in this case.
-          tf_broadcaster_.sendTransform(area_description_T_start_of_service_);
+          tf_static_broadcaster_.sendTransform(area_description_T_start_of_service_);
         }
       }
       if (publish_pose_on_topic_) {

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -821,10 +821,10 @@ void TangoRosNode::PublishDevicePose() {
       std::unique_lock<std::mutex> lock(device_pose_thread_.data_available_mutex);
       device_pose_thread_.data_available.wait(lock);
       if (publish_pose_on_tf_) {
-        tf_static_broadcaster_.sendTransform(start_of_service_T_device_);
+        tf_broadcaster_.sendTransform(start_of_service_T_device_);
         if (area_description_T_start_of_service_.child_frame_id != "") {
           // This transform can be empty. Don't publish it in this case.
-          tf_static_broadcaster_.sendTransform(area_description_T_start_of_service_);
+          tf_broadcaster_.sendTransform(area_description_T_start_of_service_);
         }
       }
       if (publish_pose_on_topic_) {


### PR DESCRIPTION
Closes #266 
Adds setting to enable or disable the color camera to save battery. Only works on API > 23

Closes #268 
Fixes sync between settings activity and ROS parameter server.
- When parameter node is started, all settings are downloaded from ROS parameter server and local settings are uploaded to parameter server.
- Before starting the settings activity, parameters are downloaded from parameter server.
- After quitting the settings activity, parameters are uploaded to parameter server.
- Before quitting RunningActivity, parameter are downloaded from parameter server.
- Settings are downloaded before restarting Tango.
- When calling the `/tango/connect` service directly, the C++ ROS node takes care of getting parameters from the server. These settings will be synced with the local settings whenever the SettingsActivity is started next time (or when app quits).

Issues:
- At the first run of Settings activity or when ROS connection failed, the local settings are overwritten by the parameter server when parameter node starts.
- ROS parameters cannot be changed if settings activity is open. ROS parameters will be overwritten whenever a user returns to the RunningActivity.

Is this behavior correct? Are the issues acceptable?