### PR TITLE
Fix/enable cameras settings

### DIFF
--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
@@ -619,9 +619,9 @@ public class RunningActivity extends AppCompatRosActivity implements
         }
 
         HashMap<String, String> tangoConfigurationParameters = new HashMap<String, String>();
-        tangoConfigurationParameters.put(getString(R.string.pref_create_new_map_key), "boolean_default_false");
-        tangoConfigurationParameters.put(getString(R.string.pref_enable_depth_key), "boolean_default_true");
-        tangoConfigurationParameters.put(getString(R.string.pref_enable_color_camera_key), "boolean_default_true");
+        tangoConfigurationParameters.put(getString(R.string.pref_create_new_map_key), "boolean");
+        tangoConfigurationParameters.put(getString(R.string.pref_enable_depth_key), "boolean");
+        tangoConfigurationParameters.put(getString(R.string.pref_enable_color_camera_key), "boolean");
         tangoConfigurationParameters.put(getString(R.string.pref_localization_mode_key), "int_as_string");
         tangoConfigurationParameters.put(getString(R.string.pref_localization_map_uuid_key), "string");
         mParameterNode = new ParameterNode(this, tangoConfigurationParameters);

--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
@@ -619,9 +619,9 @@ public class RunningActivity extends AppCompatRosActivity implements
         }
 
         HashMap<String, String> tangoConfigurationParameters = new HashMap<String, String>();
-        tangoConfigurationParameters.put(getString(R.string.pref_create_new_map_key), "boolean");
-        tangoConfigurationParameters.put(getString(R.string.pref_enable_depth_key), "boolean");
-        tangoConfigurationParameters.put(getString(R.string.pref_enable_color_camera_key), "boolean");
+        tangoConfigurationParameters.put(getString(R.string.pref_create_new_map_key), "boolean_default_false");
+        tangoConfigurationParameters.put(getString(R.string.pref_enable_depth_key), "boolean_default_true");
+        tangoConfigurationParameters.put(getString(R.string.pref_enable_color_camera_key), "boolean_default_true");
         tangoConfigurationParameters.put(getString(R.string.pref_localization_mode_key), "int_as_string");
         tangoConfigurationParameters.put(getString(R.string.pref_localization_map_uuid_key), "string");
         mParameterNode = new ParameterNode(this, tangoConfigurationParameters);

--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/SettingsActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/SettingsActivity.java
@@ -204,6 +204,10 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements
             });
             snackbar.show();
         }
+        Preference enableColorCameraPref = mSettingsPreferenceFragment.findPreference(getString(R.string.pref_enable_color_camera_key));
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
+            enableColorCameraPref.setEnabled(true);
+        }
         Preference aboutPref = mSettingsPreferenceFragment.findPreference(getString(R.string.pref_about_app_key));
         aboutPref.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override

--- a/TangoRosStreamer/app/src/main/res/xml/pref_settings.xml
+++ b/TangoRosStreamer/app/src/main/res/xml/pref_settings.xml
@@ -48,6 +48,7 @@
             android:title="@string/pref_enable_color_camera"
             android:key="@string/pref_enable_color_camera_key"
             android:defaultValue="true"
+            android:enabled="false"
             android:summary="@string/pref_enable_color_camera_summary" />
     </PreferenceCategory>
 

--- a/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
+++ b/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
@@ -82,8 +82,11 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
 
     public void uploadPreferenceToParameterServer(String paramName) {
         String valueType = mParamNames.get(paramName);
-        if (valueType == "boolean") {
+        if (valueType == "boolean_default_false") {
             Boolean booleanValue = mSharedPreferences.getBoolean(paramName, false);
+            mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), booleanValue);
+        } else if (valueType == "boolean_default_true") {
+            Boolean booleanValue = mSharedPreferences.getBoolean(paramName, true);
             mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), booleanValue);
         } else if (valueType == "int_as_string") {
             String stringValue = mSharedPreferences.getString(paramName, "0");
@@ -98,8 +101,12 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
     public void setPreferencesFromParameterServer() {
         SharedPreferences.Editor editor = mSharedPreferences.edit();
         for (String paramName : mParamNames.keySet()) {
-            if (mParamNames.get(paramName) == "boolean") {
+            if (mParamNames.get(paramName) == "boolean_default_false") {
                 Boolean booleanValue = mConnectedNode.getParameterTree().getBoolean(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), false);
+                editor.putBoolean(paramName, booleanValue);
+            }
+            if (mParamNames.get(paramName) == "boolean_default_true") {
+                Boolean booleanValue = mConnectedNode.getParameterTree().getBoolean(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), true);
                 editor.putBoolean(paramName, booleanValue);
             }
             if (mParamNames.get(paramName) == "int_as_string") {

--- a/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
+++ b/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
@@ -82,11 +82,8 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
 
     public void uploadPreferenceToParameterServer(String paramName) {
         String valueType = mParamNames.get(paramName);
-        if (valueType == "boolean_default_false") {
+        if (valueType == "boolean") {
             Boolean booleanValue = mSharedPreferences.getBoolean(paramName, false);
-            mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), booleanValue);
-        } else if (valueType == "boolean_default_true") {
-            Boolean booleanValue = mSharedPreferences.getBoolean(paramName, true);
             mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), booleanValue);
         } else if (valueType == "int_as_string") {
             String stringValue = mSharedPreferences.getString(paramName, "0");
@@ -101,21 +98,19 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
     public void setPreferencesFromParameterServer() {
         SharedPreferences.Editor editor = mSharedPreferences.edit();
         for (String paramName : mParamNames.keySet()) {
-            if (mParamNames.get(paramName) == "boolean_default_false") {
-                Boolean booleanValue = mConnectedNode.getParameterTree().getBoolean(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), false);
-                editor.putBoolean(paramName, booleanValue);
-            }
-            if (mParamNames.get(paramName) == "boolean_default_true") {
-                Boolean booleanValue = mConnectedNode.getParameterTree().getBoolean(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), true);
-                editor.putBoolean(paramName, booleanValue);
-            }
-            if (mParamNames.get(paramName) == "int_as_string") {
-                Integer intValue = mConnectedNode.getParameterTree().getInteger(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), 0);
-                editor.putString(paramName, intValue.toString());
-            }
-            if (mParamNames.get(paramName) == "string") {
-                String stringValue = mConnectedNode.getParameterTree().getString(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), "");
-                editor.putString(paramName, stringValue);
+            if (mConnectedNode.getParameterTree().has(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName))) {
+                if (mParamNames.get(paramName) == "boolean") {
+                    Boolean booleanValue = mConnectedNode.getParameterTree().getBoolean(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), false);
+                    editor.putBoolean(paramName, booleanValue);
+                }
+                if (mParamNames.get(paramName) == "int_as_string") {
+                    Integer intValue = mConnectedNode.getParameterTree().getInteger(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), 0);
+                    editor.putString(paramName, intValue.toString());
+                }
+                if (mParamNames.get(paramName) == "string") {
+                    String stringValue = mConnectedNode.getParameterTree().getString(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), "");
+                    editor.putString(paramName, stringValue);
+                }
             }
         }
         editor.commit();


### PR DESCRIPTION
This PR fixes some bugs regarding the enable depth/color camera parameters:
* When starting with a fresh roscore, they were set to false instead of true by default.
* When reconnecting to Tango to change their value, it was hanging when trying to stop the threads.

It also disables the switch preference for the color camera in case the android device is running with API < 23.