### PR TITLE
Fix shared preferences null

### DIFF
--- a/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
+++ b/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
@@ -81,6 +81,11 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
     }
 
     public void uploadPreferenceToParameterServer(String paramName) {
+        if (mSharedPreferences == null) {
+            // Cannot use mLog here because it is null.
+            System.out.println("Shared preferences are null, failed to edit.");
+            return;
+        }
         String valueType = mParamNames.get(paramName);
         if (valueType == "boolean") {
             Boolean booleanValue = mSharedPreferences.getBoolean(paramName, false);
@@ -96,6 +101,11 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
 
     // Set app preferences according to ROS params.
     public void setPreferencesFromParameterServer() {
+        if (mSharedPreferences == null) {
+            // Cannot use mLog here because it is null.
+            System.out.println("Shared preferences are null, failed to edit.");
+            return;
+        }
         SharedPreferences.Editor editor = mSharedPreferences.edit();
         for (String paramName : mParamNames.keySet()) {
             if (mConnectedNode.getParameterTree().has(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName))) {


### PR DESCRIPTION
SharedPreferences object in ParameterNode can be null if ROS master not start successfully. This leads to a crash due to NullPointerException if a user tries to go to SettingsActivity in this case to e.g. set the correct Master URI.

Closes #301