### PR TITLE
Fix load newly saved map

### DIFF
--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
@@ -349,12 +349,8 @@ public class RunningActivity extends AppCompatRosActivity implements
                     mSnackbarLoadNewMap.setAction(getString(R.string.snackbar_action_text_load_new_map), new View.OnClickListener() {
                         @Override
                         public void onClick(View view) {
-                            SharedPreferences.Editor editor = mSharedPref.edit();
-                            editor.putBoolean(getString(R.string.pref_create_new_map_key), false);
-                            editor.putString(getString(R.string.pref_localization_mode_key), "3");
-                            editor.putString(getString(R.string.pref_localization_map_uuid_key), mapUuid);
-                            editor.commit();
-                            mParameterNode.uploadPreferencesToParameterServer();
+                            mParameterNode.changeSettingsToLocalizeInMap(mapUuid, getString(R.string.pref_create_new_map_key),
+                                    getString(R.string.pref_localization_mode_key), getString(R.string.pref_localization_map_uuid_key));
                             restartTango();
                         }
                     });

--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
@@ -354,6 +354,7 @@ public class RunningActivity extends AppCompatRosActivity implements
                             editor.putString(getString(R.string.pref_localization_mode_key), "3");
                             editor.putString(getString(R.string.pref_localization_map_uuid_key), mapUuid);
                             editor.commit();
+                            mParameterNode.uploadPreferencesToParameterServer();
                             restartTango();
                         }
                     });

--- a/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
+++ b/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
@@ -20,8 +20,6 @@ import android.app.Activity;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
-import eu.intermodalics.tango_ros_common.NodeNamespaceHelper;
-
 import org.apache.commons.logging.Log;
 import org.ros.namespace.GraphName;
 import org.ros.node.AbstractNodeMain;
@@ -124,5 +122,15 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
             }
         }
         editor.commit();
+    }
+
+    public void changeSettingsToLocalizeInMap(final String mapUuid, final String prefCreateNewMapKey,
+                                              final String prefLocalizationModeKey, final String prefLocalizationMapUuidKey) {
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putBoolean(prefCreateNewMapKey, false);
+        editor.putString(prefLocalizationModeKey, "3");
+        editor.putString(prefLocalizationMapUuidKey, mapUuid);
+        editor.commit();
+        uploadPreferencesToParameterServer();
     }
 }


### PR DESCRIPTION
This fixes the feature to load  a newly saved map.
It got broken when working on syncing app preferences and ROS params.