### PR TITLE
Publish area_dexcription to sos tf as static

### DIFF
--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -984,7 +984,7 @@ void TangoRosNode::PublishDevicePose() {
         tf_broadcaster_.sendTransform(start_of_service_T_device_);
         if (area_description_T_start_of_service_.child_frame_id != "") {
           // This transform can be empty. Don't publish it in this case.
-          tf_broadcaster_.sendTransform(area_description_T_start_of_service_);
+          tf_static_broadcaster_.sendTransform(area_description_T_start_of_service_);
         }
       }
       if (start_of_service_T_device_publisher_.getNumSubscribers() > 0) {


### PR DESCRIPTION
Tango updates the transform between area_description and start_of_service only every 0.1 s. This can cause some applications to work slower than expected.

For example, in the case of the ROS navigation stack, the control loop of the [move_base](http://wiki.ros.org/move_base) package takes ~0.5 s. The reason is that it uses the [base_local_planner](http://wiki.ros.org/base_local_planner?distro=lunar) which makes several calls to [waitForTransform](http://docs.ros.org/jade/api/tf/html/c++/classtf_1_1Transformer.html#a72dc26fe7bfcb9585123309e092e5c83). Each call is blocking for between 0.1 to 0.2 s when waiting for the tf between area_description and start_of_service.

To avoid this, this PR replaces the use of tf by tf_static to publish the transform between area_description and start_of_service.
