### PR TITLE
Add api level parameter to avoid connecting to fisheye on Asus

### DIFF
--- a/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
+++ b/TangoRosStreamer/app/src/main/java/eu/intermodalics/tango_ros_streamer/activities/RunningActivity.java
@@ -27,7 +27,6 @@ import android.net.Uri;
 import android.content.res.Configuration;
 import android.net.wifi.WifiManager;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.StrictMode;
 import android.preference.PreferenceManager;
@@ -61,14 +60,9 @@ import org.ros.node.NodeMainExecutor;
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import eu.intermodalics.nodelet_manager.TangoNodeletManager;
 import eu.intermodalics.nodelet_manager.TangoInitializationHelper;
@@ -753,35 +747,7 @@ public class RunningActivity extends AppCompatRosActivity implements
         tangoConfigurationParameters.put(getString(R.string.pref_localization_map_uuid_key), "string");
         mParameterNode = new ParameterNode(this, tangoConfigurationParameters);
         nodeConfiguration.setNodeName(mParameterNode.getDefaultNodeName());
-        nodeMainExecutor.execute(mParameterNode, nodeConfiguration, new ArrayList<NodeListener>(){{
-            add(new DefaultNodeListener() {
-                @Override
-                public void onStart(final ConnectedNode connectedNode) {
-                    class SetParameterAndroidApiLevelTask implements Callable<Boolean> {
-                        @Override
-                        public Boolean call() throws Exception{
-                            while (connectedNode.getParameterTree() == null) {
-                                try {
-                                    Thread.sleep(200);
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                    return false;
-                                }
-                            }
-                            mParameterNode.setIntParam("android_api_level", Build.VERSION.SDK_INT);
-                            return true;
-                        }
-                    };
-                    ExecutorService executor = Executors.newSingleThreadExecutor();
-                    try {
-                        executor.invokeAll(Arrays.asList(new SetParameterAndroidApiLevelTask()), 5, TimeUnit.SECONDS);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    executor.shutdown();
-                }
-            });
-        }});
+        nodeMainExecutor.execute(mParameterNode, nodeConfiguration);
         // ServiceClient node which is responsible for calling ros services.
         mTangoServiceClientNode = new TangoServiceClientNode();
         mTangoServiceClientNode.setCallbackListener(this);

--- a/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
+++ b/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
@@ -159,4 +159,16 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
     public String getStringParam(String paramName) {
         return mConnectedNode.getParameterTree().getString(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), "");
     }
+
+    public void setBoolParam(String paramName, Boolean value) {
+         mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), value);
+    }
+
+    public void setIntParam(String paramName, Integer value) {
+        mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), value);
+    }
+
+    public void setStringParam(String paramName, String value) {
+        mConnectedNode.getParameterTree().set(NodeNamespaceHelper.BuildTangoRosNodeNamespaceName(paramName), value);
+    }
 }

--- a/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
+++ b/tango_ros_common/tango_ros_common/src/main/java/eu/intermodalics/tango_ros_common/ParameterNode.java
@@ -18,6 +18,7 @@ package eu.intermodalics.tango_ros_common;
 
 import android.app.Activity;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.preference.PreferenceManager;
 
 import org.apache.commons.logging.Log;
@@ -59,6 +60,7 @@ public class ParameterNode extends AbstractNodeMain implements NodeMain {
         mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(mCreatorActivity);
         mConnectedNode = connectedNode;
         mLog = connectedNode.getLog();
+        setIntParam("android_api_level", Build.VERSION.SDK_INT);
         syncLocalPreferencesWithParameterServer();
     }
 

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_node.h
@@ -234,6 +234,7 @@ class TangoRosNode : public ::nodelet::Nodelet {
   bool enable_color_camera_ = true;
   bool enable_3dr_mesh_ = true;
   bool enable_3dr_occupancy_grid_ = true;
+  bool fisheye_camera_available_ = true;
   std::string start_of_service_frame_id_;
   std::string area_description_frame_id_;
 

--- a/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_node.cpp
@@ -390,6 +390,7 @@ TangoErrorType TangoRosNode::OnTangoServiceConnected() {
                                       queue_size, latching);
       } catch (const image_transport::Exception& e) {
         LOG(ERROR) << "Error while creating color image transport publishers" << e.what();
+        return TANGO_ERROR;
       }
   } else {
     color_camera_publisher_.shutdown();
@@ -420,6 +421,7 @@ TangoErrorType TangoRosNode::OnTangoServiceConnected() {
                                        queue_size, latching);
       } catch (const image_transport::Exception& e) {
         LOG(ERROR) << "Error while creating fisheye image transport publishers" << e.what();
+        return TANGO_ERROR;
       }
   } else {
     fisheye_camera_publisher_.shutdown();
@@ -442,6 +444,7 @@ TangoErrorType TangoRosNode::OnTangoServiceConnected() {
   }
   if (pose.status_code != TANGO_POSE_VALID) {
     LOG(ERROR) << "Error, could not get a first valid pose.";
+    UpdateAndPublishTangoStatus(TangoStatus::NO_FIRST_VALID_POSE);
     return TANGO_INVALID;
   }
   time_offset_ = ros::Time::now().toSec() - GetBootTimeInSecond();
@@ -683,7 +686,6 @@ TangoErrorType TangoRosNode::ConnectToTangoAndSetUpNode() {
   PublishStaticTransforms();
   success = OnTangoServiceConnected();
   if (success != TANGO_SUCCESS) {
-    UpdateAndPublishTangoStatus(TangoStatus::NO_FIRST_VALID_POSE);
     return success;
   }
   area_description_T_start_of_service_.child_frame_id = "";


### PR DESCRIPTION
`TangoService_connectOnFrameAvailable` is not supported on Asus phones for the fisheye camera. This was causing the app to fail connecting to Tango on Asus phones.

To fix this, this PR exposes the API level of the device on a ROS parameter and decide to connect to 'onFrameAvailable' or not  (Asus phone has API level 24 while Lenovo has 23).

Fixes #314.