### PR TITLE
Release tango_ros_messages as binary packages into ROS indigo and kinetic

### DIFF
--- a/tango_ros_common/tango_ros_messages/package.xml
+++ b/tango_ros_common/tango_ros_messages/package.xml
@@ -12,7 +12,6 @@
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <run_depend>message_generation</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
 


### PR DESCRIPTION
This is required to release `tango_ros_messages` version 1.3.1 using bloom.

All other packages cannot easily be submitted for binary releases to the ROS build farm because the third-party dependencies, including the Tango Client API, cannot be released without permission and are not available for all ROS target platforms. But the message package is already useful to communicate with the TangoRosStreamer app running on an Android device.