### PR TITLE
Add laser scan range parameter.

### DIFF
--- a/tango_ros_common/tango_ros_native/cfg/Publisher.cfg
+++ b/tango_ros_common/tango_ros_native/cfg/Publisher.cfg
@@ -7,5 +7,7 @@ gen = ParameterGenerator()
 
 gen.add("laser_scan_max_height",  double_t ,  0, "Max height of the laser scan in meter",            1.0)
 gen.add("laser_scan_min_height",  double_t ,  0, "Min height of the laser scan in meter",           -1.0)
+gen.add("laser_scan_min_range",  double_t ,  0, "Min range of the laser scan in meter",              0.3)
+gen.add("laser_scan_max_range",  double_t ,  0, "Max range of the laser scan in meter",              4.0)
 
 exit(gen.generate(PACKAGE, "tango_ros_native", "Publisher"))

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_conversions_helper.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_conversions_helper.h
@@ -64,7 +64,8 @@ void toPointCloud2(const TangoPointCloud& tango_point_cloud,
 // included in laser scan.
 // @param laser_scan, the output LaserScan containing the range data.
 void toLaserScanRange(double x, double y, double z, double min_height,
-                      double max_height, sensor_msgs::LaserScan* laser_scan);
+                      double max_height, double min_range, double max_range,
+                      sensor_msgs::LaserScan* laser_scan);
 
 // Converts a TangoPointCloud to a sensor_msgs::LaserScan.
 // @param tango_point_cloud, TangoPointCloud to convert.
@@ -81,6 +82,8 @@ void toLaserScan(const TangoPointCloud& tango_point_cloud,
                  double time_offset,
                  double min_height,
                  double max_height,
+                 double min_range,
+                 double max_range,
                  const tf::Transform& point_cloud_T_laser,
                  sensor_msgs::LaserScan* laser_scan);
 

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_nodelet.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_nodelet.h
@@ -58,8 +58,8 @@ const float LASER_SCAN_ANGLE_MAX = 3.1415;
 const float LASER_SCAN_ANGLE_INCREMENT = 3.1415 / 360;
 const float LASER_SCAN_TIME_INCREMENT = 0.0;
 const float LASER_SCAN_SCAN_TIME= 0.3333;
-const float LASER_SCAN_RANGE_MIN = 0.15;
-const float LASER_SCAN_RANGE_MAX = 4.0;
+const float LASER_SCAN_MIN_RANGE = 0.3;
+const float LASER_SCAN_MAX_RANGE = 4.0;
 const std::string LASER_SCAN_FRAME_ID = "laser";
 
 const std::string DATASET_DEFAULT_DIRECTORY = "/sdcard/tango_ros_streamer/datasets/";
@@ -256,6 +256,8 @@ class TangoRosNodelet : public ::nodelet::Nodelet {
   sensor_msgs::LaserScan laser_scan_;
   double laser_scan_max_height_ = 1.0;
   double laser_scan_min_height_ = -1.0;
+  double laser_scan_max_range_ = 4.0;
+  double laser_scan_min_range_ = 0.3;
 
   std::shared_ptr<image_transport::ImageTransport> image_transport_;
   image_transport::CameraPublisher fisheye_camera_publisher_;

--- a/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_nodelet.h
+++ b/tango_ros_common/tango_ros_native/include/tango_ros_native/tango_ros_nodelet.h
@@ -58,8 +58,6 @@ const float LASER_SCAN_ANGLE_MAX = 3.1415;
 const float LASER_SCAN_ANGLE_INCREMENT = 3.1415 / 360;
 const float LASER_SCAN_TIME_INCREMENT = 0.0;
 const float LASER_SCAN_SCAN_TIME= 0.3333;
-const float LASER_SCAN_MIN_RANGE = 0.3;
-const float LASER_SCAN_MAX_RANGE = 4.0;
 const std::string LASER_SCAN_FRAME_ID = "laser";
 
 const std::string DATASET_DEFAULT_DIRECTORY = "/sdcard/tango_ros_streamer/datasets/";

--- a/tango_ros_common/tango_ros_native/src/tango_ros_conversions_helper.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_conversions_helper.cpp
@@ -119,15 +119,8 @@ void toLaserScan(const TangoPointCloud& tango_point_cloud,
                                     tango_point_cloud.points[i][1],
                                     tango_point_cloud.points[i][2]);
     tf::Vector3 laser_scan_p  = point_cloud_T_laser.inverse() * point_cloud_p;
-    toLaserScanRange(
-        laser_scan_p.getX(),
-        laser_scan_p.getY(),
-        laser_scan_p.getZ(),
-        min_height,
-        max_height,
-        min_range,
-        max_range,
-        laser_scan);
+    toLaserScanRange(laser_scan_p.getX(), laser_scan_p.getY(), laser_scan_p.getZ(),
+        min_height, max_height, min_range, max_range, laser_scan);
   }
   laser_scan->header.stamp.fromSec(tango_point_cloud.timestamp + time_offset);
 }

--- a/tango_ros_common/tango_ros_native/src/tango_ros_conversions_helper.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_conversions_helper.cpp
@@ -71,9 +71,14 @@ void toPointCloud2(const TangoPointCloud& tango_point_cloud,
 }
 
 void toLaserScanRange(double x, double y, double z, double min_height,
-                      double max_height, sensor_msgs::LaserScan* laser_scan) {
+                      double max_height, double min_range, double max_range,
+                      sensor_msgs::LaserScan* laser_scan) {
   if (std::isnan(x) || std::isnan(y) || std::isnan(z)) {
     // NAN point.
+    return;
+  }
+  double distance = sqrt(x * x  + y * y + z * z);
+  if (distance < min_range || distance > max_range) {
     return;
   }
   if (z > max_height || z < min_height) {
@@ -105,6 +110,8 @@ void toLaserScan(const TangoPointCloud& tango_point_cloud,
                  double time_offset,
                  double min_height,
                  double max_height,
+                 double min_range,
+                 double max_range,
                  const tf::Transform& point_cloud_T_laser,
                  sensor_msgs::LaserScan* laser_scan) {
   for (size_t i = 0; i < tango_point_cloud.num_points; ++i) {
@@ -112,8 +119,15 @@ void toLaserScan(const TangoPointCloud& tango_point_cloud,
                                     tango_point_cloud.points[i][1],
                                     tango_point_cloud.points[i][2]);
     tf::Vector3 laser_scan_p  = point_cloud_T_laser.inverse() * point_cloud_p;
-    toLaserScanRange(laser_scan_p.getX(), laser_scan_p.getY(), laser_scan_p.getZ(),
-                     min_height, max_height, laser_scan);
+    toLaserScanRange(
+        laser_scan_p.getX(),
+        laser_scan_p.getY(),
+        laser_scan_p.getZ(),
+        min_height,
+        max_height,
+        min_range,
+        max_range,
+        laser_scan);
   }
   laser_scan->header.stamp.fromSec(tango_point_cloud.timestamp + time_offset);
 }

--- a/tango_ros_common/tango_ros_native/src/tango_ros_nodelet.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_nodelet.cpp
@@ -835,14 +835,9 @@ void TangoRosNodelet::OnPointCloudAvailable(const TangoPointCloud* point_cloud) 
                                        / laser_scan_.angle_increment);
       // Laser scan rays with no obstacle data will evaluate to infinity.
       laser_scan_.ranges.assign(ranges_size, std::numeric_limits<double>::infinity());
-      tango_ros_conversions_helper::toLaserScan(
-        *point_cloud, time_offset_,
-        laser_scan_min_height_,
-        laser_scan_max_height_,
-        laser_scan_min_range_,
-        laser_scan_max_range_,
-        camera_depth_T_laser_,
-        &laser_scan_);
+      tango_ros_conversions_helper::toLaserScan(*point_cloud, time_offset_, 
+        laser_scan_min_height_, laser_scan_max_height_, laser_scan_min_range_,
+        laser_scan_max_range_, camera_depth_T_laser_, &laser_scan_);
       laser_scan_.header.frame_id = LASER_SCAN_FRAME_ID;
       laser_scan_thread_.data_available_mutex.unlock();
       laser_scan_thread_.data_available.notify_all();

--- a/tango_ros_common/tango_ros_native/src/tango_ros_nodelet.cpp
+++ b/tango_ros_common/tango_ros_native/src/tango_ros_nodelet.cpp
@@ -828,16 +828,21 @@ void TangoRosNodelet::OnPointCloudAvailable(const TangoPointCloud* point_cloud) 
       laser_scan_.angle_increment = LASER_SCAN_ANGLE_INCREMENT;
       laser_scan_.time_increment = LASER_SCAN_TIME_INCREMENT;
       laser_scan_.scan_time = LASER_SCAN_SCAN_TIME;
-      laser_scan_.range_min = LASER_SCAN_RANGE_MIN;
-      laser_scan_.range_max = LASER_SCAN_RANGE_MAX;
+      laser_scan_.range_min = laser_scan_min_range_;
+      laser_scan_.range_max = laser_scan_max_range_;
       // Determine amount of rays to create.
       uint32_t ranges_size = std::ceil((laser_scan_.angle_max - laser_scan_.angle_min)
                                        / laser_scan_.angle_increment);
       // Laser scan rays with no obstacle data will evaluate to infinity.
       laser_scan_.ranges.assign(ranges_size, std::numeric_limits<double>::infinity());
       tango_ros_conversions_helper::toLaserScan(
-          *point_cloud, time_offset_, laser_scan_min_height_,
-                  laser_scan_max_height_, camera_depth_T_laser_, &laser_scan_);
+        *point_cloud, time_offset_,
+        laser_scan_min_height_,
+        laser_scan_max_height_,
+        laser_scan_min_range_,
+        laser_scan_max_range_,
+        camera_depth_T_laser_,
+        &laser_scan_);
       laser_scan_.header.frame_id = LASER_SCAN_FRAME_ID;
       laser_scan_thread_.data_available_mutex.unlock();
       laser_scan_thread_.data_available.notify_all();
@@ -1169,6 +1174,12 @@ void TangoRosNodelet::PublishMesh() {
 void TangoRosNodelet::DynamicReconfigureCallback(PublisherConfig &config, uint32_t level) {
   laser_scan_max_height_ = config.laser_scan_max_height;
   laser_scan_min_height_ = config.laser_scan_min_height;
+  laser_scan_min_range_ = config.laser_scan_min_range;
+  laser_scan_max_range_ = config.laser_scan_max_range;
+  LOG(INFO) << "laser_scan_min_height [m]: " << laser_scan_min_height_ << std::endl;
+  LOG(INFO) << "laser_scan_max_height [m]: " << laser_scan_max_height_ << std::endl;
+  LOG(INFO) << "laser_scan_min_range [m]: " << laser_scan_min_range_ << std::endl;
+  LOG(INFO) << "laser_scan_max_range [m]: " << laser_scan_max_range_ << std::endl;
 }
 
 void TangoRosNodelet::RunRosSpin() {


### PR DESCRIPTION
This PR adds  the range parameter for the tango laser scan to skip shadow points that appear very close to the camera.

```
# Output of rosparam list | grep "laser"
/tango/laser_scan_max_height
/tango/laser_scan_max_range
/tango/laser_scan_min_height
/tango/laser_scan_min_range
```